### PR TITLE
Add debugging options to maven opts when running openmrs.

### DIFF
--- a/bin/omrs-run
+++ b/bin/omrs-run
@@ -53,7 +53,7 @@ MAVEN_HOME="${SDK_HOME}"/apache-maven
 MAVEN_EXEC="${MAVEN_HOME}"/bin
 
 # increase maven allocated memory
-export MAVEN_OPTS="-Xmx768M -XX:MaxPermSize=256M"
+export MAVEN_OPTS="-Xmx768M -XX:MaxPermSize=256M -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,suspend=n,server=y"
 MVN_PARAMS="-s ${MAVEN_HOME}/conf/settings.xml"
 
 # add maven paramters chosen by user

--- a/bin/omrs-run.bat
+++ b/bin/omrs-run.bat
@@ -112,7 +112,7 @@ if ERRORLEVEL 1 (
   exit /B 1
 )
 
-set MAVEN_OPTS=-Xmx768M -XX:MaxPermSize=256M 
+set MAVEN_OPTS=-Xmx768M -XX:MaxPermSize=256M -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,suspend=n,server=y 
 set MVN_PARAMS=-s "%MVN_HOME%\conf\settings.xml"
 
 set ARGI = 0


### PR DESCRIPTION
Being an SDK I think it would be useful to enable debugging of jetty by default.
