### PR TITLE
SDK-102 openmrs-sdk:pull added

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -19,6 +19,13 @@
     <description>OpenMRS SDK allows for rapid development of OpenMRS modules.</description>
     <url>https://wiki.openmrs.org/display/docs/OpenMRS+SDK</url>
 
+    <repositories>
+        <repository>
+            <id>jgit-repository</id>
+            <url>https://repo.eclipse.org/content/groups/releases/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Maven -->
         <dependency>
@@ -115,6 +122,18 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
+        </dependency>
+
+        <!-- JGit -->
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>4.4.0.201606070830-r</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.2</version>
         </dependency>
 
         <!--Testing-->

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Pull.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Pull.java
@@ -1,0 +1,64 @@
+package org.openmrs.maven.plugins;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.openmrs.maven.plugins.model.Server;
+import org.openmrs.maven.plugins.utility.Project;
+
+import java.io.File;
+import java.util.Set;
+
+/**
+ *  @goal pull
+ *
+ */
+public class Pull extends AbstractTask {
+
+    private static final String NO_WATCHED_MODULES_MESSAGE = "Server with id %s has no watched modules";
+    private static final String PULL_SUCCESS_MESSAGE = "Module %s have been updated successfully";
+    private static final String PULL_ERROR_MESSAGE = "Module %s could not be updated";
+
+    /**
+     * @parameter expression="${serverId}"
+     */
+    private String serverId;
+
+    public Pull() {}
+
+    public Pull(AbstractTask other) {super(other);}
+
+    public Pull(MavenProject project, MavenSession session, BuildPluginManager manager) {
+        super.mavenProject = project;
+        super.mavenSession = session;
+        super.pluginManager = manager;
+    }
+
+    @Override
+    public void executeTask() throws MojoExecutionException, MojoFailureException {
+        serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+        Server server = Server.loadServer(serverId);
+
+        if(server.hasWatchedProjects()){
+            Set<Project> watchedProjects = server.getWatchedProjects();
+            for(Project project: watchedProjects) {
+                File module = new File(project.getPath());
+                if (pullLatestUpstream(module)) {
+                    wizard.showMessage(String.format(PULL_SUCCESS_MESSAGE, project.getArtifactId()));
+                } else {
+                    wizard.showMessage(String.format(PULL_ERROR_MESSAGE, project.getArtifactId()));
+                }
+            }
+        }else {
+            wizard.showMessage(String.format(NO_WATCHED_MODULES_MESSAGE, serverId));
+        }
+    }
+
+    private boolean pullLatestUpstream(File module){
+        return false;
+    }
+
+
+}

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Pull.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Pull.java
@@ -1,30 +1,59 @@
 package org.openmrs.maven.plugins;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.jgit.api.CheckoutCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.MergeCommand;
+import org.eclipse.jgit.api.PullCommand;
+import org.eclipse.jgit.api.PullResult;
+import org.eclipse.jgit.api.RebaseCommand;
+import org.eclipse.jgit.api.RemoteAddCommand;
+import org.eclipse.jgit.api.RemoteRemoveCommand;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.errors.CheckoutConflictException;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.StashApplyFailureException;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.URIish;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.utility.Project;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Set;
 
 /**
- *  @goal pull
- *
+ * @goal pull
+ * @requiresProject false
  */
 public class Pull extends AbstractTask {
 
     private static final String NO_WATCHED_MODULES_MESSAGE = "Server with id %s has no watched modules";
     private static final String PULL_SUCCESS_MESSAGE = "Module %s have been updated successfully";
-    private static final String PULL_ERROR_MESSAGE = "Module %s could not be updated";
+    private static final String PULL_ERROR_MESSAGE = "Module %s could not be updated automatically due to %s";
+    private static final String CONFLICT_MESSAGE = "conflicts";
+    private static final String UPDATE_MANUALLY_MESSAGE = "Changes need to be pulled manually\n";
+    private static final String UPDATING_MODULE_MESSAGE = "Module %s is being updated to the latest upstream master";
+    private static final String CREATING_LOCAL_REPO_ERROR = "problem when initializing local repository";
+    private static final String GIT_COMMAND_ERROR = "problem with resolving git command";
+    private static final String CREATING_TEMP_REMOTE_ERROR = "problem with creating temporary remote to perform automatic update";
 
     /**
      * @parameter expression="${serverId}"
      */
     private String serverId;
+
+    private String failureReason;
 
     public Pull() {}
 
@@ -42,22 +71,153 @@ public class Pull extends AbstractTask {
         Server server = Server.loadServer(serverId);
 
         if(server.hasWatchedProjects()){
+            boolean pullingError = false;
             Set<Project> watchedProjects = server.getWatchedProjects();
             for(Project project: watchedProjects) {
-                File module = new File(project.getPath());
-                if (pullLatestUpstream(module)) {
+                wizard.showMessage(String.format(UPDATING_MODULE_MESSAGE, project.getArtifactId()));
+                if (pullLatestUpstream(project.getPath())) {
                     wizard.showMessage(String.format(PULL_SUCCESS_MESSAGE, project.getArtifactId()));
                 } else {
-                    wizard.showMessage(String.format(PULL_ERROR_MESSAGE, project.getArtifactId()));
+                    getLog().error(String.format(PULL_ERROR_MESSAGE, project.getArtifactId(), failureReason));
+                    getLog().error(UPDATE_MANUALLY_MESSAGE);
+                    pullingError = true;
                 }
+            }
+            if(pullingError){
+                throw new MojoExecutionException("Some modules could not be updated automatically, please see error messages above");
             }
         }else {
             wizard.showMessage(String.format(NO_WATCHED_MODULES_MESSAGE, serverId));
         }
     }
 
-    private boolean pullLatestUpstream(File module){
+    private boolean pullLatestUpstream(String path) throws MojoExecutionException {
+        Repository localRepo;
+        Git git = null;
+        String previousBranch;
+        String newBranchFull;
+        String newBranch = "sdk-" + serverId;
+        try {
+            localRepo = new FileRepository(new File(path, ".git").getAbsolutePath());
+            git = new Git(localRepo);
+
+            previousBranch = localRepo.getBranch();
+
+            checkoutAndCreateNewBranch(git, newBranch);
+            newBranchFull = localRepo.getFullBranch();
+            RevCommit stash = git.stashCreate().call();
+            addRemoteTempRepo(git, path, newBranch);
+            PullResult pullResult = pullFromRemote(git, newBranch);
+            if(!pullResult.isSuccessful()){
+                rebaseAbort(git);
+                checkoutBranch(git, previousBranch);
+                failureReason = CONFLICT_MESSAGE;
+                return false;
+            }
+            if (stash != null) {
+                try {
+                    git.stashApply().setStashRef(stash.getName()).call();
+                    checkoutBranch(git, previousBranch);
+                    mergeWithNewBranch(git, newBranchFull);
+                    return true;
+                } catch (StashApplyFailureException e) {
+                    git.reset().setMode(ResetCommand.ResetType.HARD).setRef(previousBranch).call();
+                    checkoutBranch(git, previousBranch);
+                    git.stashApply().setStashRef(stash.getName()).call();
+                    failureReason = CONFLICT_MESSAGE;
+                    return false;
+                }
+            } else {
+                checkoutBranch(git, previousBranch);
+                mergeWithNewBranch(git, newBranchFull);
+                return true;
+            }
+
+        } catch (IOException e) {
+            failureReason = CREATING_LOCAL_REPO_ERROR;
+        } catch (CheckoutConflictException e) {
+            failureReason = CONFLICT_MESSAGE;
+        } catch (GitAPIException e) {
+            failureReason = GIT_COMMAND_ERROR;
+        } catch (URISyntaxException e) {
+            failureReason = CREATING_TEMP_REMOTE_ERROR;
+        } finally {
+            cleanUpBranchesAndRemotes(git, newBranch);
+        }
+
         return false;
+
+    }
+
+    private void checkoutBranch(Git git, String previousBranch) throws GitAPIException {
+        git.checkout()
+                .setCreateBranch(false)
+                .setName(previousBranch)
+                .call();
+    }
+
+    private PullResult pullFromRemote(Git git, String newBranch) throws GitAPIException {
+        PullCommand pull = git.pull()
+                .setRebase(true)
+                .setRemote(newBranch)
+                .setRemoteBranchName("master");
+        return pull.call();
+    }
+
+    private void rebaseAbort(Git git) throws GitAPIException {
+        git.rebase()
+                .setOperation(RebaseCommand.Operation.ABORT)
+                .call();
+    }
+
+    private void cleanUpBranchesAndRemotes(Git git, String newBranch){
+        try {
+            deleteTempBranch(git);
+            deleteRemoteTempRepo(git, newBranch);
+        } catch (GitAPIException e) {
+            throw new RuntimeException("Couldn't delete new branch or remote", e);
+        }
+    }
+
+    private void deleteTempBranch(Git git) throws GitAPIException {
+        git.branchDelete()
+                .setForce(true)
+                .setBranchNames("sdk-"+serverId)
+                .call();
+    }
+
+    private void mergeWithNewBranch(Git git, String newBranchFull) throws IOException, GitAPIException {
+        MergeCommand mergeCommand = git.merge();
+        mergeCommand.include(git.getRepository().getRef(newBranchFull));
+        mergeCommand.call();
+    }
+
+    private void checkoutAndCreateNewBranch(Git git, String newBranch) throws GitAPIException {
+        CheckoutCommand checkoutCommand = git.checkout();
+        checkoutCommand.setCreateBranch(true);
+        checkoutCommand.setName(newBranch);
+        checkoutCommand.call();
+    }
+
+    private boolean addRemoteTempRepo(Git git,String path, String branchName) throws URISyntaxException, MojoExecutionException, GitAPIException {
+        RemoteAddCommand remoteAddCommand = git.remoteAdd();
+        remoteAddCommand.setUri(new URIish(getRemoteRepoUrlFromPom(path)));
+        remoteAddCommand.setName(branchName);
+        remoteAddCommand.call();
+        return true;
+    }
+
+    private void deleteRemoteTempRepo(Git git, String branchName) throws GitAPIException {
+        RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
+        remoteRemoveCommand.setName(branchName);
+        remoteRemoveCommand.call();
+    }
+
+    private String getRemoteRepoUrlFromPom(String path) throws MojoExecutionException {
+        Project project = Project.loadProject(new File(path));
+        Model model = project.getModel();
+        String url = model.getScm().getUrl();
+        return StringUtils.removeEnd(url, "/") + ".git";
     }
 
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/CompositeException.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/CompositeException.java
@@ -1,0 +1,38 @@
+package org.openmrs.maven.plugins.utility;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ *
+ */
+public class CompositeException extends Exception {
+
+    private Map<String, Exception> exceptions = new LinkedHashMap<>();
+
+    public CompositeException(String message) {
+        super(message);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for(Map.Entry<String, Exception> exception: exceptions.entrySet()){
+            builder.append("\n").append(exception.getKey()).append("\n").append("\t").append(ExceptionUtils.getFullStackTrace(exception.getValue()));
+        }
+        return builder.toString();
+    }
+
+    public void add(String path, Exception e) {
+        exceptions.put(path, e);
+    }
+
+    public void checkAndThrow() throws MojoExecutionException{
+        if(!exceptions.isEmpty()){
+            throw new MojoExecutionException(getMessage(), this);
+        }
+    }
+}

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -176,6 +176,11 @@ public class DefaultWizard implements Wizard {
         System.out.println("\n" + textToShow);
     }
 
+    @Override
+    public void showError(String textToShow) {
+        System.out.println("\n[ERROR]" + textToShow);
+    }
+
     /**
      * Prompt for a value with list of proposed values
      * @param value

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Project.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Project.java
@@ -83,8 +83,8 @@ public class Project {
 	}
 
 	/**
-	 * Get model object
-	 * 
+	 * get Model object
+	 *
 	 * @return
      */
 	public Model getModel() { return model; }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Project.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Project.java
@@ -82,7 +82,12 @@ public class Project {
 		return model.getParent();
 	}
 
-	public Model getModel(){ return model; }
+	/**
+	 * Get model object
+	 * 
+	 * @return
+     */
+	public Model getModel() { return model; }
 	
 	/**
 	 * Get artifactId

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -33,6 +33,8 @@ public interface Wizard {
 
     void showMessage(String message);
 
+    void showError(String message);
+
     String promptForValueIfMissingWithDefault(String message, String value, String parameterName, String defValue);
 
     String promptForValueWithDefaultList(String value, String parameterName, List<String> values);

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
             <name>OpenMRS repository</name>
             <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
         </repository>
+        <repository>
+            <id>jgit-repository</id>
+            <url>https://repo.eclipse.org/content/groups/releases/</url>
+        </repository>
     </repositories>
 
     <distributionManagement>
@@ -209,6 +213,13 @@
                 <groupId>javax.servlet</groupId>
                 <artifactId>jstl</artifactId>
                 <version>1.2</version>
+            </dependency>
+
+            <!-- JGit -->
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>4.4.0.201606070830-r</version>
             </dependency>
 
             <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,6 @@
             <name>OpenMRS repository</name>
             <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
         </repository>
-        <repository>
-            <id>jgit-repository</id>
-            <url>https://repo.eclipse.org/content/groups/releases/</url>
-        </repository>
     </repositories>
 
     <distributionManagement>
@@ -213,13 +209,6 @@
                 <groupId>javax.servlet</groupId>
                 <artifactId>jstl</artifactId>
                 <version>1.2</version>
-            </dependency>
-
-            <!-- JGit -->
-            <dependency>
-                <groupId>org.eclipse.jgit</groupId>
-                <artifactId>org.eclipse.jgit</artifactId>
-                <version>4.4.0.201606070830-r</version>
             </dependency>
 
             <!-- Testing -->


### PR DESCRIPTION
So, I'm not really sure if I did it in the proper way, but when catching exception instead of throwing one I'm setting the failureReason which is then printed to the user. 
I didn't throw for example RuntimeException, because I think it's better to try pull changes for every watched module and thet print which one were updated successfully and which one wasn't.

Another thing is when calling git.stashApply there is no way to check the stash message if there were any conflicts(like you can when doing pull rebase) so I'm reverting all changes in catch block. 