### PR TITLE
SDK-86 install OWA module when deploying OWA if not installed yet

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/DeployIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/DeployIntegrationTest.java
@@ -9,8 +9,11 @@ import org.openmrs.maven.plugins.model.DistroProperties;
 import org.openmrs.maven.plugins.model.Server;
 
 import java.io.File;
+import java.util.Arrays;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.openmrs.maven.plugins.SdkMatchers.hasNameStartingWith;
 import static org.openmrs.maven.plugins.SdkMatchers.hasUserOwa;
 import static org.openmrs.maven.plugins.SdkMatchers.serverHasVersion;
 
@@ -91,7 +94,7 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
     }
 
     @Test
-    public void deploy_shouldInstallOwa() throws Exception {
+    public void deploy_shouldInstallOwaAndOwaModule() throws Exception {
         addTaskParam("serverId", testServerId);
         addTaskParam("owa", "conceptdictionary:1.0.0-beta.6");
 
@@ -100,6 +103,12 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
         assertSuccess();
         assertFilePresent(testServerId+ File.separator+"owa");
         assertFilePresent(testServerId+ File.separator+"owa"+File.separator+"conceptdictionary");
+
+        //check if any owa module is installed
+        File modulesDir = new File(testDirectory, testServerId+File.separator+"modules");
+
+        //can't check for specific file, as always the latest release is installed
+        assertThat(Arrays.asList(modulesDir.listFiles()), hasItem(hasNameStartingWith("owa")));
 
         Server.setServersPath(testDirectory.getAbsolutePath());
         Server server = Server.loadServer(testServerId);

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/SdkMatchers.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/SdkMatchers.java
@@ -6,11 +6,13 @@ import org.openmrs.maven.plugins.bintray.BintrayId;
 import org.openmrs.maven.plugins.bintray.BintrayPackage;
 import org.openmrs.maven.plugins.model.Server;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class SdkMatchers {
@@ -44,6 +46,14 @@ public class SdkMatchers {
             @Override
             protected String featureValueOf(final BintrayPackage actual) {
                 return actual.getRepository();
+            }
+        };
+    }
+    public static Matcher<File> hasNameStartingWith(final String namePrefix) {
+        return new FeatureMatcher<File, String>(startsWith(namePrefix), "file with name", "file with name") {
+            @Override
+            protected String featureValueOf(final File actual) {
+                return actual.getName();
             }
         };
     }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -184,10 +184,30 @@ public class Deploy extends AbstractTask {
             List<String> versions = bintray.getOwaMetadata(name).getVersions();
             version = wizard.promptForMissingValueWithOptions("Which version would you like to deploy?%s", version, "", versions, true);
         }
-        wizard.showMessage("Please remember that to run OWA you need to have openmrs-owa-module installed on the server");
+
+        boolean installOwaModule = true;
+        List<Artifact> serverModules = server.getServerModules();
+        Artifact owaModule = new Artifact("owa-omod", "");
+        for(Artifact module : serverModules){
+            if(owaModule.getArtifactId().equals(module.getArtifactId())){
+                installOwaModule = false;
+                break;
+            }
+        }
+        if(installOwaModule){
+            wizard.showMessage("No installation of OWA module found on this server, will install latest version");
+            owaModule.setVersion(versionsHelper.getLatestReleasedVersion(owaModule));
+            deployModule(
+                    owaModule.getGroupId(),
+                    owaModule.getArtifactId(),
+                    owaModule.getVersion(),
+                    server
+            );
+        }
+
         File owaDir = new File(server.getServerDirectory(), "owa");
         if(!owaDir.exists()){
-            //couldn't find place where owa dir is saved yet
+            //OWA module has option to set custom app folder
             boolean useDefaultDir = wizard.promptYesNo(String.format(
                     "\nThere is no default directory '%s' on server %s, would you like to create it? (if not, you will be asked for path to custom directory)",
                     Server.OWA_DIRECTORY,

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/Bintray.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/Bintray.java
@@ -14,7 +14,7 @@ import java.net.URL;
 import java.util.List;
 
 public class Bintray {
-    public static List<BintrayId> getAvailablePackages(String owner, String repo){
+    public List<BintrayId> getAvailablePackages(String owner, String repo){
         String url = String.format("https://api.bintray.com/repos/%s/%s/packages", owner, repo);
         GetMethod get = new GetMethod(url);
         try {
@@ -33,7 +33,7 @@ public class Bintray {
         }
     }
 
-    public static BintrayPackage getPackageMetadata(String owner, String repo, String name){
+    public BintrayPackage getPackageMetadata(String owner, String repo, String name){
         String url = String.format("https://api.bintray.com/packages/%s/%s/%s", owner, repo, name);
         GetMethod get = new GetMethod(url);
         try {
@@ -51,7 +51,7 @@ public class Bintray {
         }
     }
 
-    public static List<BintrayFile> getPackageFiles(String owner, String repo, String name, String version){
+    public List<BintrayFile> getPackageFiles(String owner, String repo, String name, String version){
         String url = String.format("https://api.bintray.com/packages/%s/%s/%s/versions/%s/files", owner, repo, name, version);
         GetMethod get = new GetMethod(url);
         try {
@@ -70,7 +70,7 @@ public class Bintray {
         }
     }
 
-    public static void downloadPackage(File destDirectory, String owner, String repo, String name, String version){
+    public void downloadPackage(File destDirectory, String owner, String repo, String name, String version){
         List<BintrayFile> files = getPackageFiles(owner, repo, name, version);
         for(BintrayFile file : files){
             downloadFile(file, destDirectory, null);
@@ -83,7 +83,7 @@ public class Bintray {
      * @param filename optional, if not passed, name is bintray file name
      * @return
      */
-    public static File downloadFile(BintrayFile file, File destDirectory, String filename){
+    public File downloadFile(BintrayFile file, File destDirectory, String filename){
         try {
             if(filename == null){
                 filename = file.getName();
@@ -101,13 +101,13 @@ public class Bintray {
         }
     }
 
-    public static void downloadPackage(File destDirectory, BintrayPackage bintrayPackage){
+    public void downloadPackage(File destDirectory, BintrayPackage bintrayPackage){
         downloadPackage(
                 destDirectory,
                 bintrayPackage,
                 bintrayPackage.getLatestVersion());
     }
-    public static void downloadPackage(File destDirectory, BintrayPackage bintrayPackage, String version){
+    public void downloadPackage(File destDirectory, BintrayPackage bintrayPackage, String version){
         downloadPackage(
                 destDirectory,
                 bintrayPackage.getOwner(),

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
@@ -15,22 +15,23 @@ public class OpenmrsBintray {
 
     private static final String OWA_PACKAGE_EXTENSION = ".zip";
 
+    private Bintray bintray = new Bintray();
 
     public List<BintrayId> getAvailableOWA() throws MojoExecutionException {
-        return Bintray.getAvailablePackages(BINTRAY_OPENMRS_USER, BINTRAY_OWA_REPO);
+        return bintray.getAvailablePackages(BINTRAY_OPENMRS_USER, BINTRAY_OWA_REPO);
     }
 
     public BintrayPackage getOwaMetadata(String name) throws MojoExecutionException {
-        return Bintray.getPackageMetadata(BINTRAY_OPENMRS_USER, BINTRAY_OWA_REPO, name);
+        return bintray.getPackageMetadata(BINTRAY_OPENMRS_USER, BINTRAY_OWA_REPO, name);
     }
     public void downloadOWA(File destination, String name, String version) {
         if(!destination.exists()){
             destination.mkdir();
         }
-        List<BintrayFile> bintrayFiles = Bintray.getPackageFiles(BINTRAY_OPENMRS_USER, BINTRAY_OWA_REPO, name, version);
+        List<BintrayFile> bintrayFiles = bintray.getPackageFiles(BINTRAY_OPENMRS_USER, BINTRAY_OWA_REPO, name, version);
         //Assumption: owa release is single zip file
         String packageName = parseOwaNameFromFile(bintrayFiles.get(0).getPath())+ OWA_PACKAGE_EXTENSION;
-        File downloadedFile = Bintray.downloadFile(bintrayFiles.get(0), destination, packageName);
+        File downloadedFile = bintray.downloadFile(bintrayFiles.get(0), destination, packageName);
         extractOwa(downloadedFile);
         downloadedFile.delete();
     }


### PR DESCRIPTION
It is follow-up to #20. Introduced changes:
- when deploying OWA, server is checked if it has OWA module. If not, its latest version is installed
- `Bintray` class methods are non-static
- I left option to install OWA in custom directory(explained here https://github.com/openmrs/openmrs-sdk/pull/20#discussion_r68741143), but commented it better in code. If we decide we won't support this, I will delete this feature.