### PR TITLE
SDK-119 Improve wizard

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/AbstractSdkIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/AbstractSdkIntegrationTest.java
@@ -151,6 +151,8 @@ public abstract class AbstractSdkIntegrationTest {
      * @throws VerificationException
      */
     public void executeTask(String goal) throws Exception {
+        addTaskParam(BATCH_ANSWERS, getAnswers());
+        addTaskParam("testMode", "true");
         String sdk = resolveSdkArtifact();
         verifier.executeGoal(sdk+":"+goal);
     }

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/BuildIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/BuildIntegrationTest.java
@@ -44,7 +44,6 @@ public class BuildIntegrationTest extends AbstractSdkIntegrationTest{
         addTaskParam("openMRSPath",testDirectory.getAbsolutePath());
 
         addAnswer(serverId);
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
 
         executeTask("build");

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/CreateProjectIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/CreateProjectIntegrationTest.java
@@ -59,7 +59,6 @@ public class CreateProjectIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer("test");
         addAnswer("test");
         addAnswer("test");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("create-project");
         assertSuccess();

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/DeployIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/DeployIntegrationTest.java
@@ -36,7 +36,6 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
         addTaskParam("platform", "1.11.5");
 
         addAnswer(testServerId);
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("deploy");
 
@@ -53,7 +52,6 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer("Distribution");
         addAnswer("referenceapplication:2.3.1");
         addAnswer("y");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("deploy");
 
@@ -72,7 +70,6 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer(testServerId);
         addAnswer("y");
         addAnswer("y");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("deploy");
 
@@ -90,7 +87,6 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer(testServerId);
         addAnswer("y");
         addAnswer("y");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
         executeTask("deploy");
 
         assertSuccess();
@@ -103,7 +99,6 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer(testServerId);
         addAnswer("n");
         addAnswer("y");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
         executeTask("deploy");
 
         assertSuccess();
@@ -116,7 +111,6 @@ public class DeployIntegrationTest extends AbstractSdkIntegrationTest {
 
         addAnswer(testServerId);
         addAnswer("y");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("deploy");
 

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/PullIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/PullIntegrationTest.java
@@ -52,7 +52,6 @@ public class PullIntegrationTest extends AbstractSdkIntegrationTest {
         addWatchedProjects();
 
         addAnswer(serverId);
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask(PULL_GOAL);
 

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/SetupIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/SetupIntegrationTest.java
@@ -25,7 +25,6 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         addMockDbSettings();
         addAnswer(serverId);
         addAnswer(System.getProperty("java.home"));
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("setup");
 
@@ -52,7 +51,6 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
 
         addAnswer(serverId);
         addAnswer(System.getProperty("java.home"));
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("setup");
 
@@ -77,7 +75,7 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
 
         addAnswer(serverId);
         addAnswer(System.getProperty("java.home"));
-        addTaskParam(BATCH_ANSWERS, getAnswers());
+
 
         executeTask("setup");
 
@@ -95,7 +93,6 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         addMockDbSettings();
 
         addAnswer(System.getProperty("java.home"));
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("setup");
 
@@ -116,7 +113,6 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer("Distribution");
         addAnswer("referenceapplication:2.4");
         addAnswer(System.getProperty("java.home"));
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         executeTask("setup");
         assertSuccess();
@@ -140,7 +136,6 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         addAnswer(serverId);
         addAnswer("Distribution");
         addAnswer("referenceapplication:2.4");
-        addTaskParam(BATCH_ANSWERS, getAnswers());
 
         addMockDbSettings();
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -72,12 +72,11 @@ public abstract class AbstractTask extends AbstractMojo {
     Wizard wizard;
 
     /**
-     * Interactive mode flag, set for 'false' allows automatic testing in batch mode,
-     * as it makes all 'yes/no' prompts return 'yes'
+     * test mode, if true disables interactive mode and uses batchAnswers, even if there is none
      *
-     * @parameter expression="${interactiveMode}" default-value="true"
+     * @parameter expression="${testMode}" default-value="false"
      */
-    String interactiveMode;
+    String testMode;
 
     /**
      * path to openmrs directory
@@ -153,7 +152,7 @@ public abstract class AbstractTask extends AbstractMojo {
         if(StringUtils.isNotBlank(openMRSPath)){
             Server.setServersPath(openMRSPath);
         }
-        if(batchAnswers != null && !batchAnswers.isEmpty()){
+        if((batchAnswers != null && !batchAnswers.isEmpty())||"true".equals(testMode)){
             wizard.setAnswers(batchAnswers);
             wizard.setInteractiveMode(false);
         }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateProject.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateProject.java
@@ -147,12 +147,11 @@ public class CreateProject extends CreateProjectFromArchetypeMojo {
     private List<ArtifactRepository> remoteArtifactRepositories;
 
     /**
-     * User settings use to check the interactiveMode.
+     * test mode, if true disables interactive mode and uses batchAnswers, even if there is none
      *
-     * @parameter expression="${interactiveMode}" default-value="true"
-     * @required
+     * @parameter expression="${testMode}" default-value="false"
      */
-    private Boolean interactiveMode;
+    String testMode;
 
     /** @parameter expression="${basedir}" */
     private File basedir;
@@ -310,14 +309,12 @@ public class CreateProject extends CreateProjectFromArchetypeMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
-        if(batchAnswers != null && batchAnswers.size() != 0){
+        if((batchAnswers != null && !batchAnswers.isEmpty())||"true".equals(testMode)){
             wizard.setAnswers(batchAnswers);
             wizard.setInteractiveMode(false);
         }
 
-
         new StatsManager(wizard, session).incrementGoalStats();
-
         String choice = wizard.promptForMissingValueWithOptions(MODULE_TYPE_PROMPT, type, null, Arrays.asList(OPTION_PLATFORM, OPTION_REFAPP));
 
         if(OPTION_PLATFORM.equals(choice)){

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateProject.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateProject.java
@@ -318,9 +318,7 @@ public class CreateProject extends CreateProjectFromArchetypeMojo {
 
         new StatsManager(wizard, session).incrementGoalStats();
 
-        String choice = wizard.promptForMissingValueWithOptions(
-                MODULE_TYPE_PROMPT, type, null,
-                Arrays.asList(OPTION_PLATFORM, OPTION_REFAPP), null, null);
+        String choice = wizard.promptForMissingValueWithOptions(MODULE_TYPE_PROMPT, type, null, Arrays.asList(OPTION_PLATFORM, OPTION_REFAPP));
 
         if(OPTION_PLATFORM.equals(choice)){
             type = TYPE_PLATFORM;

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -136,7 +136,7 @@ public class Deploy extends AbstractTask {
                 DEPLOY_DISTRO_OPTION,
                 DEPLOY_PLATFORM_OPTION
                 ));
-        String choice = wizard.promptForMissingValueWithOptions("What would you like to deploy?%s", null, "", options, null, null);
+        String choice = wizard.promptForMissingValueWithOptions("What would you like to deploy?%s", null, "", options);
 
         switch(choice){
             case(DEPLOY_MODULE_OPTION):{

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -149,7 +149,7 @@ public class Deploy extends AbstractTask {
                         "Reference Application distribution",
                         server.getVersion()));
 
-                distro = wizard.promptForDistroVersion();
+                distro = wizard.promptForRefAppVersion(versionsHelper);
                 distroProperties = distroHelper.retrieveDistroProperties(distro);
                 upgrader.upgradeToDistro(server, distroProperties);
                 break;

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -370,7 +370,7 @@ public class Setup extends AbstractTask {
             options.add(DISTRIBUTION);
             options.add(PLATFORM);
 
-            String choice = wizard.promptForMissingValueWithOptions(SETUP_SERVERS_PROMPT, null, null, options, null, null);
+            String choice = wizard.promptForMissingValueWithOptions(SETUP_SERVERS_PROMPT, null, null, options);
 
             switch(choice) {
                 case PLATFORM:

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -144,7 +144,7 @@ public class Setup extends AbstractTask {
                 wizard.promptForPlatformVersionIfMissing(server, versionsHelper.getVersionAdvice(webapp, 6));
                 moduleInstaller.installCoreModules(server, isCreatePlatform, distroProperties);
             } else {
-                wizard.promptForDistroVersionIfMissing(server);
+                wizard.promptForRefAppVersionIfMissing(server, versionsHelper);
                 distroProperties = extractDistroToServer(server, isCreatePlatform, serverPath);
                 distroProperties.saveTo(server.getServerDirectory());
             }
@@ -352,7 +352,7 @@ public class Setup extends AbstractTask {
                 .setDbUri(dbUri)
                 .setDbUser(dbUser)
                 .setDbPassword(dbPassword)
-                .setInteractiveMode(interactiveMode)
+                .setInteractiveMode(testMode)
                 .setJavaHome(javaHome)
                 .build();
         wizard.promptForNewServerIfMissing(server);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -434,9 +434,9 @@ public class DefaultWizard implements Wizard {
     }
 
 	@Override
-    public void promptForDistroVersionIfMissing(Server server) throws MojoExecutionException {
+    public void promptForRefAppVersionIfMissing(Server server, VersionsHelper versionsHelper) throws MojoExecutionException {
         if(server.getVersion()==null){
-            String choice = promptForDistroVersion();
+            String choice = promptForRefAppVersion(versionsHelper);
             Artifact distro = DistroHelper.parseDistroArtifact(choice);
             if(distro != null){
                 server.setVersion(distro.getVersion());
@@ -450,11 +450,14 @@ public class DefaultWizard implements Wizard {
         }
     }
 
-    public String promptForDistroVersion() {
+    public String promptForRefAppVersion(VersionsHelper versionsHelper) {
+        int maxOptionsSize = 5;
         Map<String, String> optionsMap = new LinkedHashMap<>();
-        optionsMap.put(String.format(REFAPP_OPTION_TMPL, "2.4"), String.format(REFAPP_ARTIFACT_TMPL, "2.4"));
-        for(String version : SDKConstants.SUPPPORTED_REFAPP_VERSIONS_2_3_1_OR_LOWER){
+        Set<String> versions = new LinkedHashSet<>(versionsHelper.getVersionAdvice(SDKConstants.getReferenceModule("2.3.1"), maxOptionsSize));
+        versions.addAll(SDKConstants.SUPPPORTED_REFAPP_VERSIONS_2_3_1_OR_LOWER);
+        for(String version : versions){
             optionsMap.put(String.format(REFAPP_OPTION_TMPL, version), String.format(REFAPP_ARTIFACT_TMPL, version));
+            if(optionsMap.size()== maxOptionsSize) break;
         }
 
         String version = promptForMissingValueWithOptions(DISTRIBUTION_VERSION_PROMPT,

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -140,9 +140,15 @@ public class DefaultWizard implements Wizard {
     }
 
     @Override
+    public String promptForMissingValueWithOptions(String message, String value, String parameterName, List<String> options){
+        return promptForMissingValueWithOptions(message, value, parameterName, options, null, null);
+    }
+
+    @Override
     public String promptForMissingValueWithOptions(String message, String value, String parameterName, List<String> options, String customMessage, String customDefault){
 
-        String question = String.format(message != null? message : DEFAULT_VALUE_TMPL_WITH_DEFAULT, parameterName, options.get(0));
+        String defaultOption = options.isEmpty()? "" : options.get(0);
+        String question = String.format(message != null? message : DEFAULT_VALUE_TMPL_WITH_DEFAULT, parameterName, defaultOption);
 
         if (value != null) {
             return value;
@@ -267,7 +273,7 @@ public class DefaultWizard implements Wizard {
     public String promptForExistingServerIdIfMissing(String serverId) {
         File omrsHome = new File(Server.getServersPath());
         List<String> servers = getListOfServers();
-        serverId = promptForMissingValueWithOptions("You have the following servers:", serverId, "serverId", servers, null, null);
+        serverId = promptForMissingValueWithOptions("You have the following servers:", serverId, "serverId", servers);
         if (serverId.equals(NONE)) {
             throw new RuntimeException(INVALID_SERVER);
         }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -33,6 +33,8 @@ public interface Wizard {
 
     String promptForDistroVersion();
 
+    String promptForMissingValueWithOptions(String message, String value, String parameterName, List<String> options);
+
     String promptForMissingValueWithOptions(String message, String value, String parameterName, List<String> options, String customMessage, String customDefault);
 
     void showMessage(String message);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -6,11 +6,8 @@ import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.model.UpgradeDifferential;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 public interface Wizard {
     boolean isInteractiveMode();
@@ -29,9 +26,9 @@ public interface Wizard {
 
     String promptForPlatformVersion(List<String> versions);
 
-    void promptForDistroVersionIfMissing(Server server) throws MojoExecutionException;
+    public void promptForRefAppVersionIfMissing(Server server, VersionsHelper versionsHelper) throws MojoExecutionException;
 
-    String promptForDistroVersion();
+    String promptForRefAppVersion(VersionsHelper versionsHelper);
 
     String promptForMissingValueWithOptions(String message, String value, String parameterName, List<String> options);
 


### PR DESCRIPTION
This PR introduces changes:

- extend `Wizard` interface with method to prompt options without setting message and default value for custom
- add `testMode` property to tasks to easily disable interactive mode without batch answers
- resolve available reference application versions dynamically by using `VersionsHelper,` instead of hard-coded values