### PR TITLE
SDK-121 release SDK to Bintray on Git tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: java
 install :
-- mvn clean install -DskipTests
-- mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:3.0.0-SNAPSHOT:setup-sdk -DbatchAnswers=n
+  - mvn clean install -DskipTests
+  - mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:3.0.0-SNAPSHOT:setup-sdk -DbatchAnswers=n
+deploy:
+  provider: script
+  script: deploy.sh
+  skip_cleanup: true
+  on:
+    tags: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+mvn release:prepare
+mvn release:preform

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SettingsManager.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SettingsManager.java
@@ -3,6 +3,7 @@ package org.openmrs.maven.plugins.utility;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Profile;
+import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
 import org.apache.maven.settings.io.xpp3.SettingsXpp3Writer;
@@ -65,6 +66,11 @@ public class SettingsManager {
         Profile profile = other.getProfiles().get(0);
         if (settings.getProfiles() == null) {
             settings.setProfiles(new ArrayList<Profile>());
+        }
+        if(settings.getServer("bintray") == null) {
+            ArrayList<Server> servers = new ArrayList<>();
+            servers.add(other.getServer("bintray"));
+            settings.setServers(servers);
         }
         // remove already created OpenMRS profile
         List<Profile> profilesToRemove = new ArrayList<Profile>();

--- a/maven-plugin/src/main/resources/settings.xml
+++ b/maven-plugin/src/main/resources/settings.xml
@@ -8,6 +8,13 @@
     <activeProfiles>
         <activeProfile>openmrs</activeProfile>
     </activeProfiles>
+    <servers>
+        <server>
+            <id>bintray</id>
+            <username>${env.BINTRAY_USER}</username>
+            <password>${env.BINTRAY_API_KEY}</password>
+        </server>
+    </servers>
     <profiles>
         <profile>
             <id>openmrs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,9 @@
     </pluginRepositories>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>openmrs</id>
+            <url>https://api.bintray.com/maven/openmrs/maven/openmrs-sdk</url>
         </repository>
     </distributionManagement>
 
@@ -329,11 +325,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <useReleaseProfile>false</useReleaseProfile>
-                        <releaseProfiles>release</releaseProfiles>
+                        <releaseProfiles>bintray</releaseProfiles>
+                        <preparationGoals>clean install</preparationGoals>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>
@@ -370,19 +367,9 @@
 
     <profiles>
         <profile>
-            <id>release</id>
+            <id>bintray</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -403,19 +390,6 @@
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/release.properties
+++ b/release.properties
@@ -1,0 +1,12 @@
+#release configuration
+#Thu Jul 14 14:57:26 CEST 2016
+scm.tagNameFormat=@{project.artifactId}-@{project.version}
+pushChanges=true
+scm.url=scm\:git\:https\://github.com/AdamGrzybkowski/openmrs-sdk
+preparationGoals=clean install
+remoteTagging=true
+projectVersionPolicyId=default
+scm.commentPrefix=[maven-release-plugin] 
+exec.additionalArguments=-P openmrs
+exec.snapshotReleasePluginAllowed=false
+completedPhase=check-poms


### PR DESCRIPTION
@rkorytkowski I can't make the release plugin work to deploy to bintray. It would be great if you could check it and try it. 
Before running mvn release:x command run SDKsetup to change your settings.xml file and add environment variables BINTRAY_USER and BINTRAY_API_KEY. 

I got an error with authorization when doing mvn release:perform, so it seems like it can't see env. var. but I tried doing this with the credentials hardcoded in setting.xml and nothing changed.