### PR TITLE
SDK-86 followup: fix deploying module with flags

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -103,7 +103,7 @@ public class Deploy extends AbstractTask {
          */
         ServerUpgrader serverUpgrader = new ServerUpgrader(this);
 
-        if((platform == null && distro == null && owa == null)){
+        if((platform == null && distro == null && owa == null) && artifactId == null){
             Artifact artifact = checkCurrentDirectoryForOpenmrsWebappUpdate(server);
             DistroProperties distroProperties = checkCurrentDirectoryForDistroProperties(server);
             if(artifact != null){
@@ -123,6 +123,8 @@ public class Deploy extends AbstractTask {
         } else if(owa != null){
             BintrayId id = OpenmrsBintray.parseOwa(owa);
             deployOwa(server, id.getName(), id.getVersion());
+        } else if(artifactId != null){
+            deployModule(serverId, groupId, artifactId, version);
         } else throw new MojoExecutionException("Invalid installation option");
     }
 


### PR DESCRIPTION
Small fix, we noticed that if user wants to deploy module running sdk with flags(`-DartifactId=...` etc.) interactive mode with prompt asking what sdk has to do showes up anyway. This PR fixes it.