### PR TITLE
SDK 126 - multiple fixes 

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -68,24 +68,19 @@ public class RunTomcat extends AbstractMojo {
 		Server server = Server.loadServer(serverId);
 		String jdk = System.getProperty("java.version");
 
-		boolean isJdkValid;
-		String recommendedJdk;
-
 		Version platformVersion = new Version(server.getPlatformVersion());
 		if(platformVersion.getMajorVersion() == 1){
-			isJdkValid = (jdk.startsWith("1.7"));
-			recommendedJdk = "JDK 1.7";
+			if((jdk.startsWith("1.8"))){
+				wizard.showMessage("Please note that it is not recommended to run OpenMRS platform "+server.getPlatformVersion()+" on JDK 8.\n");
+			}
 		} else if (platformVersion.getMajorVersion() == 2){
-			isJdkValid =  (jdk.startsWith("1.8"));
-			recommendedJdk = "JDK 1.8";
+			if(!(jdk.startsWith("1.8"))){
+				wizard.showJdkErrorMessage(jdk, server.getPlatformVersion(), "JDK 1.8", server.getPropertiesFile().getPath());
+				throw new MojoExecutionException(String.format("The JDK %s is not compatible with OpenMRS Platform %s. ",
+						"JDK 1.8", server.getPlatformVersion()));
+			}
 		} else {
 			throw new MojoExecutionException("Invalid server platform version: "+platformVersion.toString());
-		}
-
-		if(!isJdkValid){
-			wizard.showJdkErrorMessage(jdk, server.getPlatformVersion(), recommendedJdk, server.getPropertiesFile().getPath());
-			throw new MojoExecutionException(String.format("The JDK %s is not compatible with OpenMRS Platform %s. ",
-					jdk, server.getPlatformVersion()));
 		}
 
 		File tempDirectory = server.getServerTmpDirectory();

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -125,16 +125,8 @@ public class Setup extends AbstractTask {
      * @throws MojoExecutionException
      */
     public String setup(Server server, boolean isCreatePlatform, boolean isCopyDependencies, DistroProperties distroProperties) throws MojoExecutionException, MojoFailureException {
-        File openMRS = Server.getServersPathFile();
         wizard.promptForNewServerIfMissing(server);
-
-        File serverPath = new File(openMRS, server.getServerId());
-        if (Server.hasServerConfig(serverPath)) {
-            Server props = Server.loadServer(serverPath);
-            if (props.getServerId() != null) {
-                throw new MojoExecutionException("Server with the same id already exists");
-            }
-        }
+        File serverPath = new File(Server.getServersPathFile(), server.getServerId());
         server.setServerDirectory(serverPath);
 
         if (distroProperties == null) {
@@ -362,6 +354,11 @@ public class Setup extends AbstractTask {
                 .setJavaHome(javaHome)
                 .build();
         wizard.promptForNewServerIfMissing(server);
+
+        File serverDir = new File(Server.getServersPath(), server.getServerId());
+        if (serverDir.isDirectory() && serverDir.exists()) {
+            throw new MojoExecutionException("Cannot create server: directory with name "+serverDir.getName()+" already exists");
+        }
 
         boolean createPlatform = false;
         DistroProperties distroProperties = null;

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -16,6 +18,7 @@ import org.openmrs.maven.plugins.model.Artifact;
 import org.openmrs.maven.plugins.model.DistroProperties;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.model.UpgradeDifferential;
+import org.openmrs.maven.plugins.model.Version;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -536,7 +539,11 @@ public class DefaultWizard implements Wizard {
         Map<String, String> optionsMap = new LinkedHashMap<>();
         Set<String> versions = new LinkedHashSet<>(versionsHelper.getVersionAdvice(SDKConstants.getReferenceModule("2.3.1"), maxOptionsSize));
         versions.addAll(SDKConstants.SUPPPORTED_REFAPP_VERSIONS_2_3_1_OR_LOWER);
+        List<ArtifactVersion> artifactVersions = new ArrayList<>();
         for(String version : versions){
+            artifactVersions.add(new DefaultArtifactVersion(version));
+        }
+        for(String version : versionsHelper.getVersionAdvice(artifactVersions, 5)){
             optionsMap.put(String.format(REFAPP_OPTION_TMPL, version), String.format(REFAPP_ARTIFACT_TMPL, version));
             if(optionsMap.size()== maxOptionsSize) break;
         }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -614,7 +614,11 @@ public class DefaultWizard implements Wizard {
         Map<Long, String> sortedMap = new TreeMap<Long, String>(Collections.reverseOrder());
         File [] list = (openMRS.listFiles() == null) ? new File[0] : openMRS.listFiles();
         for (File f: list) {
-            if (f.isDirectory()) sortedMap.put(f.lastModified(), f.getName());
+            if (f.isDirectory()){
+                if(Server.hasServerConfig(f)){
+                    sortedMap.put(f.lastModified(), f.getName());
+                }
+            }
         }
         return new ArrayList<String>(sortedMap.values());
     }


### PR DESCRIPTION
- add logic to prevent creating new server in already existing directory
- improve logic of resolving suggested reference application versions, now it should work fine no matter which versions user has in maven local repository
- replace error with warning when running OpenMRS platform 1.x with JDK 8