### PR TITLE
SDK-130 fix query in searching container by name

### DIFF
--- a/docker-maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractDockerMojo.java
+++ b/docker-maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractDockerMojo.java
@@ -76,8 +76,9 @@ abstract class AbstractDockerMojo extends AbstractMojo {
             }
         }
 
+        String name = "/"+id;
         for (Container container: containers) {
-            if (Arrays.asList(container.getNames()).contains(id)) {
+            if (Arrays.asList(container.getNames()).contains(name)) {
                 return container;
             }
         }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
@@ -97,7 +97,7 @@ public class Run extends AbstractTask {
 		}
 
 		if (Boolean.FALSE.equals(fork)) {
-			new RunTomcat(serverId, port, wizard).execute();
+			new RunTomcat(serverId, port, mavenSession, mavenProject, pluginManager, wizard).execute();
 		} else {
 			runInFork(server);
 		}

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -79,10 +79,13 @@ public class RunTomcat extends AbstractMojo {
 	public RunTomcat() {
 	}
 
-	public RunTomcat(String serverId, Integer port, Wizard wizard) {
+	public RunTomcat(String serverId, Integer port, MavenSession mavenSession, MavenProject mavenProject, BuildPluginManager pluginManager, Wizard wizard) {
 		this.serverId = serverId;
 		this.port = port;
 		this.wizard = wizard;
+		this.mavenProject = mavenProject;
+		this.mavenSession = mavenSession;
+		this.pluginManager = pluginManager;
 	}
 
 	@Override


### PR DESCRIPTION
Docker plugin doesn't find container when name is passed, because java-docker appends "/" prefix to every container name.