### PR TITLE
SDK-126 fixes in delete goal

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -319,6 +319,9 @@ public class DefaultWizard implements Wizard {
     public String promptForExistingServerIdIfMissing(String serverId) {
         File omrsHome = new File(Server.getServersPath());
         List<String> servers = getListOfServers();
+        if(servers.isEmpty()){
+            throw new RuntimeException("There is no servers available");
+        }
         serverId = promptForMissingValueWithOptions("You have the following servers:", serverId, "serverId", servers);
         if (serverId.equals(NONE)) {
             throw new RuntimeException(INVALID_SERVER);


### PR DESCRIPTION
Before deleting server DB we are running docker container if server was dockerized
If there is no servers available, then throw RuntimeException when asked for existing serverId