### PR TITLE
SDK-134 Allow setting values in openmrs-runtime.properties

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/SdkMatchers.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/SdkMatchers.java
@@ -9,6 +9,8 @@ import org.openmrs.maven.plugins.model.Artifact;
 import org.openmrs.maven.plugins.model.Server;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -54,6 +56,14 @@ public class SdkMatchers {
             @Override
             protected String featureValueOf(final File actual) {
                 return actual.getName();
+            }
+        };
+    }
+    public static Matcher<Server> hasPropertyEqualTo(final String propertyName, final String propertyValue) {
+        return new FeatureMatcher<Server, String>(equalTo(propertyValue), "property value", "property value") {
+            @Override
+            protected String featureValueOf(final Server actual) {
+                return actual.getCustomProperties().get(propertyName);
             }
         };
     }

--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/SetupIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/SetupIntegrationTest.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.openmrs.maven.plugins.SdkMatchers.hasPropertyEqualTo;
 import static org.openmrs.maven.plugins.SdkMatchers.serverHasVersion;
 
 public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
@@ -74,6 +75,7 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         addMockDbSettings();
 
         addAnswer(serverId);
+        addAnswer("nameValue");
         addAnswer(System.getProperty("java.home"));
 
 
@@ -84,6 +86,11 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         assertFilePresent(serverId + File.separator + "openmrs-1.11.5.war");
         assertFilePresent(serverId + File.separator + "modules");
         assertModulesInstalled(serverId, "owa-1.4.omod", "uicommons-1.7.omod", "uiframework-3.6.omod");
+
+        Server.setServersPath(testDirectory.getAbsolutePath());
+        Server server = Server.loadServer(serverId);
+        assertThat(server, hasPropertyEqualTo("test", "testValue"));
+        assertThat(server, hasPropertyEqualTo("pih.default.config", "nameValue"));
     }
 
     @Test
@@ -92,6 +99,8 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         addTaskParam("serverId", serverId);
         addMockDbSettings();
 
+        addAnswer("OpenMRS Concepts OWA server 1.0 from current directory");
+        addAnswer("nameValue");
         addAnswer(System.getProperty("java.home"));
 
         executeTask("setup");
@@ -101,6 +110,11 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         assertFilePresent(serverId + File.separator + "openmrs-1.11.5.war");
         assertFilePresent(serverId + File.separator + "modules");
         assertModulesInstalled(serverId, "owa-1.4.omod", "uicommons-1.7.omod", "uiframework-3.6.omod");
+
+        Server.setServersPath(testDirectory.getAbsolutePath());
+        Server server = Server.loadServer(serverId);
+        assertThat(server, hasPropertyEqualTo("test", "testValue"));
+        assertThat(server, hasPropertyEqualTo("pih.default.config", "nameValue"));
     }
 
     @Test

--- a/integration-tests/src/test/resources/integration-test/openmrs-distro.properties
+++ b/integration-tests/src/test/resources/integration-test/openmrs-distro.properties
@@ -5,3 +5,6 @@ omod.uiframework=3.6
 omod.uicommons=1.7
 omod.owa=1.4
 db.h2.supported=true
+property.test=testValue
+property.pih.default.config.prompt=Please specify
+property.pih.default.config.default=defValue

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -153,7 +153,7 @@ public abstract class AbstractTask extends AbstractMojo {
             moduleInstaller = new ModuleInstaller(mavenProject, mavenSession, pluginManager, versionsHelper);
         }
         if(distroHelper == null){
-            distroHelper = new DistroHelper(mavenProject, mavenSession, pluginManager);
+            distroHelper = new DistroHelper(mavenProject, mavenSession, pluginManager, wizard);
         }
         if(dockerHelper == null){
             dockerHelper = new DockerHelper(mavenProject, mavenSession, pluginManager, wizard);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateProject.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateProject.java
@@ -64,8 +64,8 @@ public class CreateProject extends CreateProjectFromArchetypeMojo {
                     "which in short is: major.minor.maintenance(-SNAPSHOT).";
 
     private static final String DESCRIPTION_PROMPT_TMPL = "Describe your module in a few sentences";
-    private static final String GROUP_ID_PROMPT_TMPL = "Please specify %s (default: '%s'): ";
-    private static final String AUTHOR_PROMPT_TMPL = "Who is the author of the module? (default: '%s')";
+    private static final String GROUP_ID_PROMPT_TMPL = "Please specify %s";
+    private static final String AUTHOR_PROMPT_TMPL = "Who is the author of the module?";
     private static final String MODULE_TYPE_PROMPT = "What kind of project would you like to create?";
 
     /** @component */
@@ -308,10 +308,10 @@ public class CreateProject extends CreateProjectFromArchetypeMojo {
         moduleAuthor = wizard.promptForValueIfMissingWithDefault(AUTHOR_PROMPT_TMPL, moduleAuthor, "", "anonymous");
 
         if(TYPE_PLATFORM.equals(type)){
-            platform = wizard.promptForValueIfMissingWithDefault("What is the lowest version of the platform (-D%s) you want to support? (default: %s)", platform, "platform", "1.11.6");
+            platform = wizard.promptForValueIfMissingWithDefault("What is the lowest version of the platform (-D%s) you want to support?", platform, "platform", "1.11.6");
             archetypeArtifactId = SDKConstants.PLATFORM_ARCH_ARTIFACT_ID;
         } else if(TYPE_REFAPP.equals(type)) {
-            refapp = wizard.promptForValueIfMissingWithDefault("What is the lowest version of the Reference Application (-D%s) you want to support? (default: %s)", refapp, "refapp", "2.4");
+            refapp = wizard.promptForValueIfMissingWithDefault("What is the lowest version of the Reference Application (-D%s) you want to support?", refapp, "refapp", "2.4");
             archetypeArtifactId = SDKConstants.REFAPP_ARCH_ARTIFACT_ID;
         } else {
             throw new MojoExecutionException("Invalid project type");

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Pull.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Pull.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Pull extends AbstractTask {
 
-    private static final String ENTER_BRANCH_NAME_MESSAGE = "Enter name of the upstream branch you want to pull(default: master)";
+    private static final String ENTER_BRANCH_NAME_MESSAGE = "Enter name of the upstream branch you want to pull";
     private static final String CLEAN_UP_ERROR_MESSAGE = "problem with resolving git command. " +
                                                             "Please run \"git checkout %s\" and \"git stash apply\" in %s directory to revert changes";
     private static final String NO_WATCHED_MODULES_MESSAGE = "Server with id %s has no watched modules";

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/PullRequest.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/PullRequest.java
@@ -186,7 +186,7 @@ public class PullRequest extends AbstractTask {
         org.eclipse.egit.github.core.PullRequest pr = gitHelper.getPullRequestIfExists(branch, username +":"+originBranch, repoName);
         if(pr == null){
             wizard.showMessage("Creating new pull request...");
-            String description = wizard.promptForValueIfMissingWithDefault("You can include a short %s (optional)", null, "description", " ");
+            String description = wizard.promptForValueIfMissingWithDefault("You can include a short %s (optional)", null, "description", "");
             description = "https://issues.openmrs.org/browse/"+ issueId +"\n\n"+description;
             GithubPrRequest request = new GithubPrRequest.Builder()
                     .setBase(branch)

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -23,6 +23,7 @@ import org.openmrs.maven.plugins.utility.Wizard;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -150,6 +151,8 @@ public class RunTomcat extends AbstractMojo {
 				new File(serverPath, SDKConstants.OPENMRS_SERVER_PROPERTIES).getAbsolutePath());
 		System.setProperty("OPENMRS_APPLICATION_DATA_DIRECTORY", serverPath.getAbsolutePath() + File.separator);
 
+		setServerCustomProperties(server);
+
 		setSystemPropertiesForWatchedProjects(serverPath);
 
 		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
@@ -164,6 +167,13 @@ public class RunTomcat extends AbstractMojo {
 			throw new MojoExecutionException("Tomcat failed to start", e);
 		} finally {
 			Thread.currentThread().setContextClassLoader(originalClassLoader);
+		}
+	}
+
+	private void setServerCustomProperties(Server server) {
+		HashMap<String, String> customProperties = server.getCustomProperties();
+		for(String key: customProperties.keySet()){
+			System.setProperty(key, customProperties.get(key));
 		}
 	}
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -2,6 +2,7 @@ package org.openmrs.maven.plugins;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.lang.StringUtils;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -24,6 +25,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @goal setup
@@ -146,6 +148,7 @@ public class Setup extends AbstractTask {
                 moduleInstaller.installCoreModules(server, isCreatePlatform, distroProperties);
                 distroProperties.saveTo(server.getServerDirectory());
             }
+            distroHelper.savePropertiesToServer(distroProperties, server);
 
             if(server.getDbDriver() == null) {
                 boolean h2supported = true;

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
@@ -2,7 +2,6 @@ package org.openmrs.maven.plugins.model;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.project.MavenProject;
 
 
 import java.io.File;
@@ -11,7 +10,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -22,6 +21,7 @@ import java.util.Set;
  */
 public class DistroProperties {
 
+    public static final String PROPERTY_PROMPT_KEY = "property.%s.prompt";
     private static final String DEAFAULT_FILE_NAME = "openmrs-distro-%s.properties";
     private static final String TYPE_OMOD = "omod";
     private static final String TYPE_WAR = "war";
@@ -31,7 +31,8 @@ public class DistroProperties {
     private static final String GROUP_ID = "groupId";
     public static final String DISTRO_FILE_NAME = "openmrs-distro.properties";
     private static final String DB_SQL = "db.sql";
-
+    public static final String PROPERTY_DEFAULT_VALUE_KEY = "property.%s.default";
+    public static final String PROPERTY_KEY = "property.%s";
 
 
     private Properties properties;
@@ -192,6 +193,39 @@ public class DistroProperties {
 
     public String getName(){
         return getParam("name");
+    }
+
+    public String getPropertyPromt(String propertyName){
+        return getParam(String.format(PROPERTY_PROMPT_KEY, propertyName));
+    }
+
+    public String getPropertyDefault(String propertyName){
+        return getParam(String.format(PROPERTY_DEFAULT_VALUE_KEY, propertyName));
+    }
+
+    public String getPropertyValue(String propertyName){
+        return getParam(String.format(PROPERTY_KEY, propertyName));
+    }
+
+    public Set<String> getPropertiesNames(){
+        Set<String> propertiesNames = new HashSet<>();
+        for(Object key: getAllKeys()){
+            if(key.toString().startsWith("property.")){
+                propertiesNames.add(extractPropertyName(key.toString()));
+            }
+        }
+        return propertiesNames;
+    }
+
+    private String extractPropertyName(String key) {
+        int beginIndex = key.indexOf(".");
+        if(key.endsWith(".default")){
+            return key.substring(beginIndex+1, key.length()-8);
+        } else if(key.endsWith(".prompt")){
+            return key.substring(beginIndex+1, key.length()-7);
+        } else {
+            return key.substring(beginIndex+1);
+        }
     }
 
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Server.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Server.java
@@ -712,6 +712,10 @@ public class Server {
         setParam(PROPERTY_DOCKER_MYSQL, containerId);
     }
 
+    public void setPropertyValue(String propertyName, String value){
+        setParam("property."+propertyName, value);
+    }
+
     public void deleteServerTmpDirectory() {
         File tmpDirectory = getServerTmpDirectory();
         if (tmpDirectory.exists()) {
@@ -740,5 +744,20 @@ public class Server {
             version = version.substring(0, version.lastIndexOf(".war"));
             return version;
         }
+    }
+
+    public HashMap<String, String> getCustomProperties(){
+        HashMap<String, String> customProperties = new LinkedHashMap<>();
+        for(Object key: properties.keySet()){
+            if(key.toString().startsWith("property.")){
+                String newKey = removePropertyStringFromKey(key.toString());
+                customProperties.put(newKey, properties.getProperty(key.toString()));
+            }
+        }
+        return customProperties;
+    }
+
+    private String removePropertyStringFromKey(String key) {
+        return key.substring(key.indexOf(".")+1);
     }
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -57,7 +57,8 @@ public class DefaultWizard implements Wizard {
     private static final String DEFAULT_OPTION_TMPL = "%d) %s";
     private static final String DEFAULT_CUSTOM_OPTION_TMPL = "%d) Other...";
     private static final String DEFAULT_SERVER_NAME = "server";
-    private static final String DEFAULT_VALUE_TMPL = "Please specify %s";
+    private static final String DEFAULT_PROMPT_TMPL = "Please specify %s";
+    private static final String DEFAULT_VALUE_TMPL = " (default: '%s')";
     private static final String DEFAULT_VALUE_TMPL_WITH_DEFAULT = "Please specify %s: (default: '%s')";
     private static final String DEFAULT_FAIL_MESSAGE = "Server with such serverId is not exists";
     private static final String INVALID_SERVER = "Invalid server Id";
@@ -129,7 +130,7 @@ public class DefaultWizard implements Wizard {
             indx++;
             defaultServerId = DEFAULT_SERVER_NAME + String.valueOf(indx);
         }
-        String serverId =  promptForValueIfMissingWithDefault("Specify server id (-D%s) (default: '%s')", server.getServerId(), "serverId", defaultServerId);
+        String serverId =  promptForValueIfMissingWithDefault("Specify server id (-D%s)", server.getServerId(), "serverId", defaultServerId);
         server.setServerId(serverId);
     }
 
@@ -151,11 +152,11 @@ public class DefaultWizard implements Wizard {
 
     public String promptForValueIfMissingWithDefault(String message, String value, String parameterName, String defValue, boolean password) {
         String textToShow;
-        if (StringUtils.isBlank(defValue)){
-            textToShow = String.format(message != null ? message : DEFAULT_VALUE_TMPL, parameterName);
+        if (StringUtils.isEmpty(defValue)){
+            textToShow = String.format(message != null ? message : DEFAULT_PROMPT_TMPL, parameterName);
         }
         else {
-            textToShow = String.format(message != null? message : DEFAULT_VALUE_TMPL_WITH_DEFAULT, parameterName, defValue);
+            textToShow = String.format(message != null? message : DEFAULT_PROMPT_TMPL, parameterName) + String.format(DEFAULT_VALUE_TMPL, defValue);
         }
 
         if (value != null) {
@@ -247,7 +248,7 @@ public class DefaultWizard implements Wizard {
         } if(System.console() == null){
             return promptForValueIfMissing(value, parameter);
         }else {
-            return new String(System.console().readPassword("\n"+DEFAULT_VALUE_TMPL+": ", parameter));
+            return new String(System.console().readPassword("\n"+ DEFAULT_PROMPT_TMPL +": ", parameter));
         }
     }
 
@@ -272,7 +273,7 @@ public class DefaultWizard implements Wizard {
     public String promptForValueWithDefaultList(String value, String parameterName, List<String> values) {
         if (value != null) return value;
         String defaultValue = values.size() > 0 ? values.get(0) : NONE;
-        final String text = DEFAULT_VALUE_TMPL_WITH_DEFAULT + " (possible: %s)";
+        final String text = DEFAULT_PROMPT_TMPL + DEFAULT_VALUE_TMPL + " (possible: %s)";
         String val = prompt(String.format(text, parameterName, defaultValue, StringUtils.join(values.toArray(), ", ")));
         if (val.equals(EMPTY_STRING)) val = defaultValue;
         return val;
@@ -599,7 +600,7 @@ public class DefaultWizard implements Wizard {
         }
 
         String version = promptForMissingValueWithOptions(DISTRIBUTION_VERSION_PROMPT,
-                null, "distribution artifact", Lists.newArrayList(optionsMap.keySet()), "Please specify %s (default: '%s')", REFERENCEAPPLICATION_2_4);
+                null, "distribution artifact", Lists.newArrayList(optionsMap.keySet()), "Please specify %s", REFERENCEAPPLICATION_2_4);
 
         String artifact = optionsMap.get(version);
         if (artifact != null) {
@@ -649,7 +650,7 @@ public class DefaultWizard implements Wizard {
             server.setDbDriver(SDKConstants.DRIVER_MYSQL);
         }
         String dbUri = promptForValueIfMissingWithDefault(
-                "The distribution requires MySQL database. Please specify database uri (-D%s) (default: '%s')",
+                "The distribution requires MySQL database. Please specify database uri (-D%s)",
                 server.getDbUri(), "dbUri", SDKConstants.URI_MYSQL);
         if (dbUri.startsWith("jdbc:mysql:")) {
             dbUri = addMySQLParamsIfMissing(dbUri);
@@ -713,7 +714,7 @@ public class DefaultWizard implements Wizard {
         String dockerHost = dockerHelper.getDockerHost();
 
         String dbUri = promptForValueIfMissingWithDefault(
-                "Please specify database uri (-D%s) (default: '%s')", server.getDbUri(), "dbUri", getDefaultUri(dockerHost));
+                "Please specify database uri (-D%s)", server.getDbUri(), "dbUri", SDKConstants.URI_MYSQL);
         if (dbUri.startsWith("jdbc:mysql:")) {
             server.setDbDriver(SDKConstants.DRIVER_MYSQL);
             dbUri = addMySQLParamsIfMissing(dbUri);
@@ -743,13 +744,13 @@ public class DefaultWizard implements Wizard {
     public void promptForDbCredentialsIfMissing(Server server) {
         String defaultUser = "root";
         String user = promptForValueIfMissingWithDefault(
-                "Please specify database username (-D%s) (default: '%s')",
+                "Please specify database username (-D%s)",
                 server.getDbUser(), "dbUser", defaultUser);
         server.setDbUser(user);
         //set password
         String dbPassword = promptForValueIfMissingWithDefault(
-                "Please specify database password (-D%s) (default: '')",
-                server.getDbPassword(), "dbPassword", "");
+                "Please specify database password (-D%s)",
+                server.getDbPassword(), "dbPassword", " ");
         server.setDbPassword(dbPassword);
     }
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DockerHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DockerHelper.java
@@ -41,7 +41,7 @@ public class DockerHelper {
 
     private static final String DOCKER_HOST_MSG_LINUX = "To use dockerized MySQL, You have to pass Docker Host URL to SDK. " +
             "Authorization to access docker socket file is required. To ensure this, run command 'sudo usermod -aG docker ${USER}'." +
-            "\nPlease specify %s (default: %s)";
+            "\nPlease specify %s";
 
     private static final String DOCKER_HOST_DEFAULT_LINUX = "unix:///var/run/docker.sock";
 


### PR DESCRIPTION
@rkorytkowski 
I've changed the property options a little bit. You can specify three values in distro.properties:
1) property.%propertyName%=value
2) property.%propertyName%.prompt=value
3) property.%propertyName%.default=value
With option 1 specified wizard won't prompt for this value, if there will be only option 2 wizard will ask for value with specified prompt(option 3 is optional for default value)

The properties are then saved in openmrs-server.properties as %propertyName%=value.

The property.%propertyName% form distro can be override be passing -DpropertyName=value in command line.

Unfortunately putting properties in openmrs-servers.properties and setting them as system properties doesn't seem to solve @mogoodrich problem, I guess pih.config is not read as system value. I managed to setup PIH only with pih.config in runtime.properties. 

 Lastly I've changed promptForValueIfMissingWithDefault() method in wizzard, so the user does not have to write(in option nr 2, mentioned above) something like "Pleas specify value for someProperty, default: %s". The default String will be added automatically if defValue is specified. 