### PR TITLE
SDK-133 stop failing silently, add rollback to setup task

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Delete.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Delete.java
@@ -2,6 +2,7 @@ package org.openmrs.maven.plugins;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.openmrs.maven.plugins.model.Server;
@@ -26,8 +27,8 @@ public class Delete extends AbstractTask{
 
     public void executeTask() throws MojoExecutionException, MojoFailureException {
         serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+        Server server = loadValidatedServer(serverId);
         try {
-            Server server = loadValidatedServer(serverId);
             FileUtils.deleteDirectory(server.getServerDirectory());
 
             if(StringUtils.isNotBlank(server.getContainerId())){
@@ -50,7 +51,7 @@ public class Delete extends AbstractTask{
         } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage());
         } catch (SQLException e) {
-            throw new MojoExecutionException(e.getMessage());
+            throw new MojoExecutionException("Failed to drop database", e);
         }
     }
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Server.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Server.java
@@ -601,7 +601,7 @@ public class Server {
     }
 
     public boolean isMySqlDb() {
-        return getDbUri().startsWith("jdbc:mysql");
+        return getDbUri().startsWith("jdbc:mysql") || getDbDriver().equals(SDKConstants.DRIVER_MYSQL);
     }
 
     public String getDbUri() {


### PR DESCRIPTION
This PR introduces changes:
* improve logic to detect mysql connection. Before, SDK didn't recognize mysql URI if there was a typo in "jdbc:mysql" part. Now it does and fails to connect, which interrupts setup
* add rollback to `setup` - when setup is interrupted, SDK deletes unfinished server
* `delete` fails when dropping DB fails, instead of showing error log  