### PR TITLE
SDK-179 Fetch different versions of openmrs-distro.properties for the…

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -148,9 +148,17 @@ public class Setup extends AbstractTask {
         try {
             if (distroProperties == null) {
                 if(isCreatePlatform){
-                    Artifact webapp = new Artifact(SDKConstants.WEBAPP_ARTIFACT_ID, SDKConstants.SETUP_DEFAULT_PLATFORM_VERSION, Artifact.GROUP_WEB);
-                    wizard.promptForPlatformVersionIfMissing(server, versionsHelper.getVersionAdvice(webapp, 6));
-                    moduleInstaller.installCoreModules(server, isCreatePlatform, distroProperties);
+                    Artifact platform = new Artifact(SDKConstants.PLATFORM_ARTIFACT_ID, SDKConstants.SETUP_DEFAULT_PLATFORM_VERSION, Artifact.GROUP_DISTRO);
+                    wizard.promptForPlatformVersionIfMissing(server, versionsHelper.getVersionAdvice(platform, 6));
+                    platform.setVersion(server.getPlatformVersion());
+                    try {
+                        distroProperties = distroHelper.downloadDistroProperties(serverPath, platform);
+                        distroProperties.saveTo(server.getServerDirectory());
+                        moduleInstaller.installCoreModules(server, isCreatePlatform, distroProperties);
+                    } catch (MojoExecutionException e) {
+                        getLog().info("Fetching openmrs war file in version " + server.getPlatformVersion());
+                        moduleInstaller.installCoreModules(server, isCreatePlatform, distroProperties);
+                    }
                 } else {
                     wizard.promptForRefAppVersionIfMissing(server, versionsHelper);
                     distroProperties = extractDistroToServer(server, isCreatePlatform, serverPath);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DistroHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DistroHelper.java
@@ -2,6 +2,7 @@ package org.openmrs.maven.plugins.utility;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -239,7 +240,11 @@ public class DistroHelper {
 
     public DistroProperties downloadDistroProperties(File serverPath, Server server) throws MojoExecutionException {
         Artifact artifact = new Artifact(server.getDistroArtifactId(), server.getVersion(), server.getDistroGroupId(), "jar");
-        return downloadDistroProperties(serverPath, artifact);
+        if (StringUtils.isNotBlank(artifact.getArtifactId())) {
+            return downloadDistroProperties(serverPath, artifact);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ModuleInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ModuleInstaller.java
@@ -44,7 +44,7 @@ public class ModuleInstaller {
     public void installCoreModules(Server server, boolean isCreatePlatform, DistroProperties properties) throws MojoExecutionException, MojoFailureException {
         List<Artifact> coreModules;
         // install other modules
-        if (!isCreatePlatform && properties != null) {
+        if (properties != null) {
             coreModules = properties.getWarArtifacts();
             if (coreModules == null) {
                 throw new MojoExecutionException(String.format("Invalid version: '%s'", server.getVersion()));

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
@@ -73,6 +73,7 @@ public class SDKConstants {
     public static final String TMP = "tmp";
     // non-platform web app versions
     public static final String WEBAPP_ARTIFACT_ID = "openmrs-webapp";
+    public static final String PLATFORM_ARTIFACT_ID = "platform";
     public static final Map<String,String> WEBAPP_VERSIONS = new HashMap<String, String>() {{
         put("2.0", "1.9.7");
         put("2.1", "1.10.0");


### PR DESCRIPTION
@rkorytkowski I've modified it so now all version displayed to the user are released versions of distro-platform. When choosing custom you can fetch openrms war file by providing the version only or different platform-distro that was no displayed by typing org.openmrs.distro:platform:{version} or platform:{version}

If that is fine to you I will edit the wiki once this PR is merged 
