### PR TITLE
SDK-187 - Added support for Docker for Windows and Mac

### DIFF
--- a/docker-maven-plugin/pom.xml
+++ b/docker-maven-plugin/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.6</version>
         </dependency>
 
         <dependency>

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -84,6 +84,13 @@ public class Setup extends AbstractTask {
     private String dbSql;
 
     /**
+     * Docker host address
+     *
+     * @parameter expression="${dockerHost}"
+     */
+    private String dockerHost;
+
+    /**
      * Path to JDK Version
      *
      * @parameter expression="${javaHome}"
@@ -176,7 +183,7 @@ public class Setup extends AbstractTask {
                 if(distroProperties != null) {
                     h2supported = distroProperties.isH2Supported();
                 }
-                wizard.promptForDb(server, dockerHelper, h2supported, dbDriver);
+                wizard.promptForDb(server, dockerHelper, h2supported, dbDriver, dockerHost);
             }
 
             if(server.getDbDriver() != null){

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DockerHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DockerHelper.java
@@ -32,7 +32,8 @@ public class DockerHelper {
     public static final String DOCKER_MYSQL_USERNAME = "root";
     public static final String DOCKER_MYSQL_PASSWORD = "Admin123";
     private static final String DOCKER_HOST_KEY = "dockerHost";
-    public static final String DEFAULT_HOST_LINUX = "unix:///var/run/docker.sock";
+    public static final String DEFAULT_DOCKER_HOST_UNIX_SOCKET = "unix:///var/run/docker.sock";
+    public static final String DEFAULT_HOST_DOCKER_FOR_WINDOWS = "tcp://127.0.0.1:2375/";
 
     private static final String DOCKER_HOST_MSG_WINDOWS = "To use dockerized MySQL, You have to pass Docker Host URL to SDK. " +
             "You should run SDK from docker-machine command line, so SDK can connect to your Docker. Your individual docker host URL can be obtained by calling command" +
@@ -122,7 +123,7 @@ public class DockerHelper {
         );
 
         if(!dockerHost.equals(getDockerHost())){
-            saveDockerHost(dockerHost);
+        saveDockerHost(dockerHost);
         }
     }
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -15,7 +15,7 @@ public interface Wizard {
 
     void promptForNewServerIfMissing(Server server);
 
-    void promptForDb(Server server, DockerHelper dockerHelper, boolean h2supported, String dbDriver) throws MojoExecutionException;
+    void promptForDb(Server server, DockerHelper dockerHelper, boolean h2supported, String dbDriver, String dockerHost) throws MojoExecutionException;
 
     public void promptForMySQLDb(Server server) throws MojoExecutionException;
 


### PR DESCRIPTION
@rkorytkowski 
I am checking for **Docker for Windows** by executing HTTP Request to `http://127.0.0.1:2375/` and it works fine, but I am trying to do same for **Docker for Mac** and I don't know whats default URL in this case (I've temporary set it to `tcp://127.0.0.1:2375/`, which probably isn't correct).
It would be nice if You test is on Mac and tell me what should I put into `DEFAULT_HOST_DOCKER_FOR_MAC` constant.
You can build this code on Mac to test it, since You will be prompted for Docker host URL (if `tcp://127.0.0.1:2375/` as default Docker for Mac host address is incorrect)