### PR TITLE
SDK-191 - Store OpenMRS data in volume

### DIFF
--- a/maven-plugin/src/main/resources/build-distro/docker-compose.yml
+++ b/maven-plugin/src/main/resources/build-distro/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       DB_CREATE_TABLES: 'false'  # change to 'true' if using an empty database
       DB_ADD_DEMO_DATA: 'false'  # change to 'true' if using an empty database
       DB_AUTO_UPDATE: 'false'    # change to 'true' if using an empty database
+    volumes:
+      - web-data:/usr/local/tomcat/.OpenMRS
+      - /usr/local/tomcat/.OpenMRS/modules/ # used to mount persistent docker volume for modules
+      - /usr/local/tomcat/.OpenMRS/owa/     # used to mount persistent docker volume for owa
 
 volumes:
   db-data:
+  web-data:


### PR DESCRIPTION
By adding `/usr/local/tomcat/.OpenMRS/modules/` and `/usr/local/tomcat/.OpenMRS/owa/` to `web` service's `volumes` its possible to separate `modules` and `owa` directories content from docker volume, so every container got its own `modules` and `owa` content.