### PR TITLE
Use proxy for bintray downloads

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/OpenmrsBintrayIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/OpenmrsBintrayIntegrationTest.java
@@ -25,7 +25,7 @@ public class OpenmrsBintrayIntegrationTest extends AbstractSdkIntegrationTest {
     @Before
     public void setup() throws Exception {
         super.setup();
-        openmrsBintray = new OpenmrsBintray();
+        openmrsBintray = new OpenmrsBintray(null);
     }
     @Test
     public void getAvailableOwaTest() throws Exception{

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -8,7 +8,9 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.settings.Proxy;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.utility.DefaultJira;
 import org.openmrs.maven.plugins.utility.DistroHelper;
@@ -42,6 +44,13 @@ public abstract class AbstractTask extends AbstractMojo {
      * @parameter expression="${session}"
      */
     MavenSession mavenSession;
+
+    /**
+     * The Maven Settings
+     *
+     * @parameter expression="${settings}"
+     */
+    Settings settings;
 
     /**
      * The artifact metadata source to use.
@@ -143,6 +152,7 @@ public abstract class AbstractTask extends AbstractMojo {
         this.distroHelper = other.distroHelper;
         this.gitHelper = other.gitHelper;
         this.dockerHelper = other.dockerHelper;
+	this.settings = other.settings;
         initTask();
     }
 
@@ -189,5 +199,20 @@ public abstract class AbstractTask extends AbstractMojo {
         new ServerUpgrader(this).validateServerMetadata(serverPath);
         Server server = Server.loadServer(serverPath);
         return server;
+    }
+
+    public Proxy getProxyFromSettings() {
+        if (settings == null) {
+            return null;
+        }
+
+        // Get active http/https proxy
+        for (Proxy proxy : settings.getProxies()) {
+            if (proxy.isActive() && ("http".equalsIgnoreCase(proxy.getProtocol()) || "https".equalsIgnoreCase(proxy.getProtocol()))) {
+                return proxy;
+            }
+        }
+
+        return null;
     }
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -8,9 +8,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.settings.Proxy;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.settings.Settings;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.utility.DefaultJira;
 import org.openmrs.maven.plugins.utility.DistroHelper;
@@ -44,13 +42,6 @@ public abstract class AbstractTask extends AbstractMojo {
      * @parameter expression="${session}"
      */
     MavenSession mavenSession;
-
-    /**
-     * The Maven Settings
-     *
-     * @parameter expression="${settings}"
-     */
-    Settings settings;
 
     /**
      * The artifact metadata source to use.
@@ -152,7 +143,6 @@ public abstract class AbstractTask extends AbstractMojo {
         this.distroHelper = other.distroHelper;
         this.gitHelper = other.gitHelper;
         this.dockerHelper = other.dockerHelper;
-	this.settings = other.settings;
         initTask();
     }
 
@@ -199,20 +189,5 @@ public abstract class AbstractTask extends AbstractMojo {
         new ServerUpgrader(this).validateServerMetadata(serverPath);
         Server server = Server.loadServer(serverPath);
         return server;
-    }
-
-    public Proxy getProxyFromSettings() {
-        if (settings == null) {
-            return null;
-        }
-
-        // Get active http/https proxy
-        for (Proxy proxy : settings.getProxies()) {
-            if (proxy.isActive() && ("http".equalsIgnoreCase(proxy.getProtocol()) || "https".equalsIgnoreCase(proxy.getProtocol()))) {
-                return proxy;
-            }
-        }
-
-        return null;
     }
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/BuildDistro.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/BuildDistro.java
@@ -255,7 +255,7 @@ public class BuildDistro extends AbstractTask {
 
     private void downloadOWAs(File targetDirectory, DistroProperties distroProperties, File owasDir) throws MojoExecutionException {
         List<Artifact> owas = distroProperties.getOwaArtifacts(distroHelper, targetDirectory);
-        OpenmrsBintray openmrsBintray = new OpenmrsBintray(getProxyFromSettings());
+        OpenmrsBintray openmrsBintray = new OpenmrsBintray();
 
         if (!owas.isEmpty()) {
             wizard.showMessage("Downloading OWAs...\n");

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/BuildDistro.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/BuildDistro.java
@@ -255,7 +255,7 @@ public class BuildDistro extends AbstractTask {
 
     private void downloadOWAs(File targetDirectory, DistroProperties distroProperties, File owasDir) throws MojoExecutionException {
         List<Artifact> owas = distroProperties.getOwaArtifacts(distroHelper, targetDirectory);
-        OpenmrsBintray openmrsBintray = new OpenmrsBintray();
+        OpenmrsBintray openmrsBintray = new OpenmrsBintray(getProxyFromSettings());
 
         if (!owas.isEmpty()) {
             wizard.showMessage("Downloading OWAs...\n");

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -182,7 +182,7 @@ public class Deploy extends AbstractTask {
     }
 
     private void deployOwa(Server server, String name, String version) throws MojoExecutionException {
-        OpenmrsBintray bintray = new OpenmrsBintray(getProxyFromSettings());
+        OpenmrsBintray bintray = new OpenmrsBintray();
         if(name == null){
             List<String> owas = new ArrayList<>();
             for(BintrayId id : bintray.getAvailableOWA()){

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -182,7 +182,7 @@ public class Deploy extends AbstractTask {
     }
 
     private void deployOwa(Server server, String name, String version) throws MojoExecutionException {
-        OpenmrsBintray bintray = new OpenmrsBintray();
+        OpenmrsBintray bintray = new OpenmrsBintray(getProxyFromSettings());
         if(name == null){
             List<String> owas = new ArrayList<>();
             for(BintrayId id : bintray.getAvailableOWA()){

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Fetch.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Fetch.java
@@ -79,7 +79,7 @@ public class Fetch extends AbstractTask {
     private ProjectType projectType;
 
     public void executeTask() throws MojoExecutionException, MojoFailureException {
-        openmrsBintray = new OpenmrsBintray();
+        openmrsBintray = new OpenmrsBintray(getProxyFromSettings());
         if (StringUtils.isBlank(groupId)) {
             groupId = DEFAULT_GROUP_ID;
         }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Fetch.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Fetch.java
@@ -79,7 +79,7 @@ public class Fetch extends AbstractTask {
     private ProjectType projectType;
 
     public void executeTask() throws MojoExecutionException, MojoFailureException {
-        openmrsBintray = new OpenmrsBintray(getProxyFromSettings());
+        openmrsBintray = new OpenmrsBintray();
         if (StringUtils.isBlank(groupId)) {
             groupId = DEFAULT_GROUP_ID;
         }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Release.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Release.java
@@ -163,7 +163,7 @@ public class Release extends AbstractTask {
             );
             wizard.showMessage("Release to OpenMRS Maven Bintray repository completed");
 
-            OpenmrsBintray bintray = new OpenmrsBintray(credentials.getUserName(), credentials.getPassword());
+            OpenmrsBintray bintray = new OpenmrsBintray(getProxyFromSettings(),credentials.getUserName(), credentials.getPassword());
 
 
             File omodDir = new File(mavenProject.getBasedir(), "omod");
@@ -188,7 +188,7 @@ public class Release extends AbstractTask {
         wizard.showMessage("Omod submodule detected...");
         File omodFile = new File(omodDir, "target"+File.separator+omodName);
 
-        OpenmrsBintray openmrsBintray = new OpenmrsBintray(credentials.getUserName(), credentials.getPassword());
+        OpenmrsBintray openmrsBintray = new OpenmrsBintray(getProxyFromSettings(),credentials.getUserName(), credentials.getPassword());
         BintrayPackage bintrayPackage = openmrsBintray.getPackageMetadata(OpenmrsBintray.OPENMRS_OMOD_REPO, mavenProject.getArtifactId());
         if(bintrayPackage == null){
             bintrayPackage =  openmrsBintray.createPackage(mavenProject, OpenmrsBintray.OPENMRS_OMOD_REPO);
@@ -271,7 +271,7 @@ public class Release extends AbstractTask {
     }
 
     private String createPackageBintrayUrl(UsernamePasswordCredentials creds, String repository){
-        OpenmrsBintray bintray = new OpenmrsBintray(creds.getUserName(), creds.getPassword());
+        OpenmrsBintray bintray = new OpenmrsBintray(getProxyFromSettings(),creds.getUserName(), creds.getPassword());
         BintrayPackage bintrayPackage = bintray.getPackageMetadata(repository, mavenProject.getArtifactId());
 
         if(bintrayPackage == null){

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Release.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Release.java
@@ -163,7 +163,7 @@ public class Release extends AbstractTask {
             );
             wizard.showMessage("Release to OpenMRS Maven Bintray repository completed");
 
-            OpenmrsBintray bintray = new OpenmrsBintray(getProxyFromSettings(),credentials.getUserName(), credentials.getPassword());
+            OpenmrsBintray bintray = new OpenmrsBintray(credentials.getUserName(), credentials.getPassword());
 
 
             File omodDir = new File(mavenProject.getBasedir(), "omod");
@@ -188,7 +188,7 @@ public class Release extends AbstractTask {
         wizard.showMessage("Omod submodule detected...");
         File omodFile = new File(omodDir, "target"+File.separator+omodName);
 
-        OpenmrsBintray openmrsBintray = new OpenmrsBintray(getProxyFromSettings(),credentials.getUserName(), credentials.getPassword());
+        OpenmrsBintray openmrsBintray = new OpenmrsBintray(credentials.getUserName(), credentials.getPassword());
         BintrayPackage bintrayPackage = openmrsBintray.getPackageMetadata(OpenmrsBintray.OPENMRS_OMOD_REPO, mavenProject.getArtifactId());
         if(bintrayPackage == null){
             bintrayPackage =  openmrsBintray.createPackage(mavenProject, OpenmrsBintray.OPENMRS_OMOD_REPO);
@@ -271,7 +271,7 @@ public class Release extends AbstractTask {
     }
 
     private String createPackageBintrayUrl(UsernamePasswordCredentials creds, String repository){
-        OpenmrsBintray bintray = new OpenmrsBintray(getProxyFromSettings(),creds.getUserName(), creds.getPassword());
+        OpenmrsBintray bintray = new OpenmrsBintray(creds.getUserName(), creds.getPassword());
         BintrayPackage bintrayPackage = bintray.getPackageMetadata(repository, mavenProject.getArtifactId());
 
         if(bintrayPackage == null){

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/Bintray.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/Bintray.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.ProxyHost;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.FileRequestEntity;
@@ -14,6 +18,9 @@ import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.settings.Proxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,12 +28,19 @@ import java.net.URL;
 import java.util.List;
 
 public class Bintray {
+
+    private final Logger log = LoggerFactory.getLogger(Bintray.class);
+
     private String username;
     private String password;
+    private Proxy proxy=null;
 
-    public Bintray() {}
+    public Bintray(Proxy proxy) {
+        this.proxy=proxy;
+    }
 
-    public Bintray(String username, String password) {
+    public Bintray(Proxy proxy, String username, String password) {
+	this.proxy    = proxy;
         this.username = username;
         this.password = password;
     }
@@ -36,11 +50,53 @@ public class Bintray {
         this.password = password;
     }
 
+    private HttpClient newHttpClient() {
+	log.debug("newHttpClient");
+        HttpClient httpClient =  new HttpClient();
+
+        // if the proxy from maven settings is empty, then we rely on system properties
+	if (proxy==null) {
+	    log.debug("no proxy from maven");
+            String proxyHost = System.getProperty( "http.proxyHost" );
+            if ( proxyHost != null ) {
+               int proxyPort = 80;
+               String proxyPortStr = System.getProperty( "http.proxyPort" );
+               if (proxyPortStr != null) {
+                   try {
+                       proxyPort = Integer.parseInt( proxyPortStr );
+                   } catch (NumberFormatException e) {
+                       proxyPort = 80;
+                   }
+               }
+	       log.debug("proxy = " + proxyHost +":" + proxyPort);
+
+               ProxyHost httpProxy = new ProxyHost( proxyHost, proxyPort );
+               httpClient.getHostConfiguration().setProxyHost( httpProxy );
+           }
+       } else {
+	   log.debug("Found proxy from maven");
+	   log.debug("proxy = " + proxy.getHost() +":" + proxy.getPort());
+
+           ProxyHost httpProxy = new ProxyHost(proxy.getHost(), proxy.getPort());
+           httpClient.getHostConfiguration().setProxyHost( httpProxy );
+
+          if (proxy.getUsername() != null) {
+	      log.debug("Found credentials: " + proxy.getUsername());
+              Credentials credentials = new UsernamePasswordCredentials(proxy.getUsername(), proxy.getPassword());
+              AuthScope authScope = new AuthScope(proxy.getHost(), proxy.getPort());
+
+              httpClient.getState().setProxyCredentials(authScope, credentials);
+          }
+       }
+       return httpClient;
+
+    }
+
     public List<BintrayId> getAvailablePackages(String owner, String repo){
         String url = String.format("https://api.bintray.com/repos/%s/%s/packages", owner, repo);
         GetMethod get = new GetMethod(url);
         try {
-            new HttpClient().executeMethod(get);
+            newHttpClient().executeMethod(get);
             if (get.getStatusLine() == null || get.getStatusCode() != 200) {
                 throw new IOException(get.getStatusLine().toString());
             }
@@ -60,7 +116,7 @@ public class Bintray {
         String url = String.format("https://api.bintray.com/packages/%s/%s/%s", owner, repo, name);
         GetMethod get = new GetMethod(url);
         try {
-            new HttpClient().executeMethod(get);
+            newHttpClient().executeMethod(get);
             if (get.getStatusLine() == null || get.getStatusCode() != 200) {
                 throw new IOException(get.getStatusLine().toString());
             }
@@ -78,7 +134,7 @@ public class Bintray {
         String url = String.format("https://api.bintray.com/packages/%s/%s/%s/versions/%s/files", owner, repo, name, version);
         GetMethod get = new GetMethod(url);
         try {
-            new HttpClient().executeMethod(get);
+            newHttpClient().executeMethod(get);
             if (get.getStatusLine() == null || get.getStatusCode() != 200) {
                 throw new IOException(get.getStatusLine().toString());
             }
@@ -117,8 +173,15 @@ public class Bintray {
             }
             String url = String.format("https://dl.bintray.com/%s/%s/%s", file.getOwner(), file.getRepository(), file.getPath());
             URL fileUrl = new URL(url);
-            System.out.println("Downloading " + url);
-            FileUtils.copyURLToFile(fileUrl, destFile, 2000, 5000);
+            log.info("Downloading " + url);
+
+	    GetMethod get = new GetMethod(url);
+            newHttpClient().executeMethod(get);
+            if (get.getStatusLine() == null || get.getStatusCode() != 200) {
+                throw new IOException(url +": "+get.getStatusLine().toString());
+            }
+            FileUtils.copyInputStreamToFile(get.getResponseBodyAsStream(), destFile);
+
             return destFile;
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -148,7 +211,7 @@ public class Bintray {
         ObjectMapper mapper = new ObjectMapper();
         try{
             post.setRequestEntity(new ByteArrayRequestEntity(mapper.writeValueAsBytes(request)));
-            new HttpClient().executeMethod(post);
+            newHttpClient().executeMethod(post);
             if(post.getStatusLine() == null || post.getStatusCode()==401){
                 throw new IOException("Unauthorized, this user have no rights to publish packages as "+owner+", or API key is invalid");
             }
@@ -189,7 +252,7 @@ public class Bintray {
         put.setRequestEntity(new FileRequestEntity(file, contentType));
 
         try{
-            new HttpClient().executeMethod(put);
+            newHttpClient().executeMethod(put);
             validateAuthorizedRequestResult(bintrayPackage.getOwner(), put, 201);
         } catch (Exception e) {
             throw new RuntimeException("Failed to upload files to package: "+bintrayPackage.getName(), e);
@@ -213,7 +276,7 @@ public class Bintray {
         post.addRequestHeader("Authorization", "Basic "+ new String(Base64.encodeBase64((username+":"+password).getBytes())));
         post.setRequestEntity(new ByteArrayRequestEntity(("{\"name\":\""+versionName+"\"}").getBytes(), "application/json"));
         try{
-            new HttpClient().executeMethod(post);
+            newHttpClient().executeMethod(post);
             validateAuthorizedRequestResult(owner, post, 201);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create version in package: "+packageName, e);
@@ -227,7 +290,7 @@ public class Bintray {
         post.addRequestHeader("Authorization", "Basic "+ new String(Base64.encodeBase64((username+":"+password).getBytes())));
         post.setRequestEntity(new ByteArrayRequestEntity(("{\"publish-wait-for-secs\":\"-1\"}").getBytes(), "application/json"));
         try{
-            new HttpClient().executeMethod(post);
+            newHttpClient().executeMethod(post);
             validateAuthorizedRequestResult(owner, post, 200);
         } catch (Exception e) {
             throw new RuntimeException("Failed to publish version "+versionName+" in package: "+packageName, e);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
@@ -8,6 +8,7 @@ import net.lingala.zip4j.model.FileHeader;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Proxy;
 import org.openmrs.maven.plugins.model.PackageJson;
 import org.openmrs.maven.plugins.model.Version;
 import org.openmrs.maven.plugins.utility.DefaultJira;
@@ -30,10 +31,12 @@ public class OpenmrsBintray extends Bintray{
 
     private static final String OWA_PACKAGE_EXTENSION = ".owa";
 
-    public OpenmrsBintray() {}
+    public OpenmrsBintray(Proxy proxy) {
+        super(proxy);
+    }
 
-    public OpenmrsBintray(String username, String password) {
-        super(username, password);
+    public OpenmrsBintray(Proxy proxy,String username, String password) {
+        super(proxy,username, password);
     }
 
     public List<BintrayId> getAvailableOWA() throws MojoExecutionException {

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
@@ -8,7 +8,6 @@ import net.lingala.zip4j.model.FileHeader;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.settings.Proxy;
 import org.openmrs.maven.plugins.model.PackageJson;
 import org.openmrs.maven.plugins.model.Version;
 import org.openmrs.maven.plugins.utility.DefaultJira;
@@ -31,12 +30,10 @@ public class OpenmrsBintray extends Bintray{
 
     private static final String OWA_PACKAGE_EXTENSION = ".owa";
 
-    public OpenmrsBintray(Proxy proxy) {
-        super(proxy);
-    }
+    public OpenmrsBintray() {}
 
-    public OpenmrsBintray(Proxy proxy,String username, String password) {
-        super(proxy,username, password);
+    public OpenmrsBintray(String username, String password) {
+        super(username, password);
     }
 
     public List<BintrayId> getAvailableOWA() throws MojoExecutionException {


### PR DESCRIPTION
if you access internet through a proxy, the download of binary files via HTTP fails.
This change allows the maven-plugin of the SDK to use the proxy information stored in the global settings to connect to internet and to download files.