### PR TITLE
SDK-230: Allow empty string passwords in JDBC

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -884,9 +884,9 @@ public class DefaultWizard implements Wizard {
         server.setDbUser(user);
         //set password
         String dbPassword = promptForPasswordIfMissingWithDefault(
-                "Please specify database password (-D%s)",
-                server.getDbPassword(), "dbPassword", " ");
-        server.setDbPassword(dbPassword);
+                "Note: whitespace-only passwords will be left blank and trailing/leading whitespace will be removed.\nPlease specify database password (-D%s)",
+                server.getDbPassword(), "dbPassword", "");
+        server.setDbPassword(dbPassword.trim());
     }
 
     /**


### PR DESCRIPTION
https://issues.openmrs.org/browse/SDK-230

During SDK setup, if a user attempts to use an empty password to connect to a database,  JDBC throws a connection error.