### PR TITLE
fixed all of the incorrect references to "rootArtifactId" in the controllers

### DIFF
--- a/archetype-module-platform/src/main/resources/archetype-resources/omod/src/main/java/web/controller/__moduleClassnamePrefix__Controller.java
+++ b/archetype-module-platform/src/main/resources/archetype-resources/omod/src/main/java/web/controller/__moduleClassnamePrefix__Controller.java
@@ -28,8 +28,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * This class configured as controller using annotation and mapped with the URL of
  * 'module/${rootArtifactid}/${rootArtifactid}Link.form'.
  */
-@Controller("${rootrootArtifactid}.${moduleClassnamePrefix}Controller")
-@RequestMapping(value = "module/${rootArtifactid}/${rootArtifactid}.form")
+@Controller("${rootArtifactId}.${moduleClassnamePrefix}Controller")
+@RequestMapping(value = "/module/${rootArtifactId}/${rootArtifactId}.form")
 public class ${moduleClassnamePrefix}Controller {
 	
 	/** Logger for this class and subclasses */
@@ -39,7 +39,7 @@ public class ${moduleClassnamePrefix}Controller {
 	UserService userService;
 	
 	/** Success form view name */
-	private final String VIEW = "/module/${rootArtifactid}/${rootArtifactid}";
+	private final String VIEW = "/module/${rootArtifactId}/${rootArtifactId}";
 	
 	/**
 	 * Initially called after the getUsers method to get the landing form name

--- a/archetype-module-refapp/src/main/resources/archetype-resources/omod/src/main/java/web/controller/__moduleClassnamePrefix__Controller.java
+++ b/archetype-module-refapp/src/main/resources/archetype-resources/omod/src/main/java/web/controller/__moduleClassnamePrefix__Controller.java
@@ -28,8 +28,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * This class configured as controller using annotation and mapped with the URL of
  * 'module/${rootArtifactId}/${rootArtifactId}Link.form'.
  */
-@Controller("${rootrootArtifactId}.${moduleClassnamePrefix}Controller")
-@RequestMapping(value = "module/${rootArtifactId}/${rootArtifactId}.form")
+@Controller("${rootArtifactId}.${moduleClassnamePrefix}Controller")
+@RequestMapping(value = "/module/${rootArtifactId}/${rootArtifactId}.form")
 public class ${moduleClassnamePrefix}Controller {
 	
 	/** Logger for this class and subclasses */


### PR DESCRIPTION

For this sdk-212 jira ticket we have found very simple errors in the code specifically in the __moduleClassnamePrefix__Controller files. We have changed incorrect references to "rootArtifactId" such as "rootartifactId" and "rootArtifactid". We then tested the sdk by creating both reference applications and platform modules and observed their controllers which are now being generated correctly.