### PR TITLE
SDK-243 | Fix query to reset search indexes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk7
+jdk: openjdk8
 install :
   - mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:setup-sdk -DbatchAnswers=n
 script:

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
@@ -91,7 +91,7 @@ public class SDKConstants {
 
     public final static String NPM_VERSION = "^3.10.3";
     public final static String NODE_VERSION = "^6.4.0";
-	public static final String RESET_SEARCH_INDEX_SQL = "DELETE FROM `%s`.global_property WHERE property = 'search.indexVersion'";
+	public static final String RESET_SEARCH_INDEX_SQL = "DELETE FROM `%s`.global_property WHERE property = 'search.indexVersion';";
 
 	/**
      * Get core modules with required versions


### PR DESCRIPTION
As part of the PR:
- [x] Added the missing semicolon for the Reset Search Index Query.
- [x] Run a `openmrs-sdk-maven-plugin` `BuildDistro` with version  `3.13.3-SNAPSHOT` and verified the generated query for Reset Search Index has the expected delimiter`;`.
- [x] Run an `mvn setup` with the generated dump from `BuildDistro` for a database name `openmrs` and it works fine.

Link to the Ticket: https://issues.openmrs.org/browse/SDK-243