### PR TITLE
SDK-245: Upgrade Tomcat version in SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <tomcat.version>7.0.67</tomcat.version>
+        <tomcat.version>7.0.96</tomcat.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
See [SDK-245](https://issues.openmrs.org/browse/SDK-245).

The SDK is using a version of Tomcat that doesn't appropriately handle Jars built with the Java Module System. This PR simply bumps the version of Tomcat to a version in the 7.x series that supports these Jars.