### PR TITLE
SDK-246: Compatibility with Maven 3.6.2+

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -201,7 +201,7 @@ public class Deploy extends AbstractTask {
 
         boolean installOwaModule = true;
         List<Artifact> serverModules = server.getServerModules();
-        Artifact owaModule = new Artifact("owa-omod", "");
+        Artifact owaModule = new Artifact("owa-omod", "1.0.0");
         for(Artifact module : serverModules){
             if(owaModule.getArtifactId().equals(module.getArtifactId())){
                 installOwaModule = false;


### PR DESCRIPTION
JIRA Ticket: https://issues.openmrs.org/browse/SDK-246

We supply a dummy version to pass the validation check. Note that the actual version deployed will be the latest version of the owa-omod.

This should fix the issue with build [626](https://travis-ci.org/openmrs/openmrs-sdk/builds/617014015#L129)

## Checklist:
- [x] My PR contains only 1 commit
- [x] My IDE is configured to follow the code style for OpenMRS
- [x] Existing tests cover my changes
- [x] I ran `mvn clean package` right before creating this PR
- [x] All tests pass
- [x] Based on latest master