### PR TITLE
SDK-18: Display friendly message when server is ready

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -160,7 +160,7 @@ public class RunTomcat extends AbstractMojo {
 		tomcat.getHost().setDeployOnStartup(true);
 		tomcat.getConnector().setURIEncoding("UTF-8");
 		Context context = tomcat.addWebapp(tomcat.getHost(), "/openmrs", new File(serverPath, warFile).getAbsolutePath());
-		context.addLifecycleListener(new OpenmrsStartupListener(wizard));
+		context.addLifecycleListener(new OpenmrsStartupListener(wizard,port));
 
 		System.setProperty("OPENMRS_INSTALLATION_SCRIPT",
 				new File(serverPath, SDKConstants.OPENMRS_SERVER_PROPERTIES).getAbsolutePath());
@@ -233,11 +233,12 @@ public class RunTomcat extends AbstractMojo {
 	}
 	public static final class OpenmrsStartupListener implements LifecycleListener {
 
-		private  Wizard wizard;
-		private int port;
+		private final  Wizard wizard;
+		private final int port;
 
-		OpenmrsStartupListener(Wizard wizard) {
+		OpenmrsStartupListener(Wizard wizard, int port) {
 			this.wizard = wizard;
+			this.port = port;
 		}
 
 		@Override

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -160,7 +160,7 @@ public class RunTomcat extends AbstractMojo {
 		tomcat.getHost().setDeployOnStartup(true);
 		tomcat.getConnector().setURIEncoding("UTF-8");
 		Context context = tomcat.addWebapp(tomcat.getHost(), "/openmrs", new File(serverPath, warFile).getAbsolutePath());
-		context.addLifecycleListener(new OpenmrsStartupListener(wizard,port));
+		context.addLifecycleListener(new OpenmrsStartupListener(wizard, port));
 
 		System.setProperty("OPENMRS_INSTALLATION_SCRIPT",
 				new File(serverPath, SDKConstants.OPENMRS_SERVER_PROPERTIES).getAbsolutePath());
@@ -231,6 +231,7 @@ public class RunTomcat extends AbstractMojo {
 	private boolean isWatchApi() {
 		return Boolean.TRUE.equals(watchApi);
 	}
+	
 	public static final class OpenmrsStartupListener implements LifecycleListener {
 
 		private final  Wizard wizard;

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -1,7 +1,10 @@
 package org.openmrs.maven.plugins;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.commons.io.FileUtils;
@@ -157,6 +160,7 @@ public class RunTomcat extends AbstractMojo {
 		tomcat.getHost().setDeployOnStartup(true);
 		tomcat.getConnector().setURIEncoding("UTF-8");
 		Context context = tomcat.addWebapp(tomcat.getHost(), "/openmrs", new File(serverPath, warFile).getAbsolutePath());
+		context.addLifecycleListener(new OpenmrsStartupListener(wizard));
 
 		System.setProperty("OPENMRS_INSTALLATION_SCRIPT",
 				new File(serverPath, SDKConstants.OPENMRS_SERVER_PROPERTIES).getAbsolutePath());
@@ -227,5 +231,22 @@ public class RunTomcat extends AbstractMojo {
 	private boolean isWatchApi() {
 		return Boolean.TRUE.equals(watchApi);
 	}
+	public static final class OpenmrsStartupListener implements LifecycleListener {
 
+		private  Wizard wizard;
+		private int port;
+
+		OpenmrsStartupListener(Wizard wizard) {
+			this.wizard = wizard;
+		}
+
+		@Override
+		public void lifecycleEvent(LifecycleEvent event) {
+			if (!Lifecycle.AFTER_START_EVENT.equals(event.getType())) {
+				return;
+			}
+
+			wizard.showMessage(String.format("OpenMRS is ready for you at http://localhost:%s/openmrs/", port == 80 ? "" : ":" + port));
+		}
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -334,8 +334,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.5.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>8</source>
+                        <target>8</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Description of what I did:
I enabled  the display of the  the server url on the last line before calling jetty url as "OpenMRS is ready for you at http://localhost:8080/openmrs/" . To achieve this, I did the following:
1. import org.apache.catalina.LifecycleEvent , import org.pache.catalina.LifecycleListener; and  import org.apache.catalina.LifecycleListener; because they are used inside the OpenmrsStartListener.
2. Added OpenmrsStartListener class
3. Display the message requested per the ticket description.
4. I changed `<source 1.7</source>` to `<source>8</source>` and likewise for `<target>`. so that, i can take advantage of Java 8’s lambda expressions 

Issue worked on:
https://issues.openmrs.org/browse/SDK-18