### PR TITLE
SDK-222: Allow user to specify port to use when default taken

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
@@ -131,22 +131,22 @@ public class Run extends AbstractTask {
 	}
 
 	private void validatePort() {
-	    int tmpPort = port;
+		int tmpPort = port;
 
-	    tmpPort = serverHelper.findFreePort(tmpPort);
-	    if (port != tmpPort) {
-	        String message = String.format("Port %s is already in use. What port would you like to use?", port);
+		tmpPort = serverHelper.findFreePort(tmpPort);
+		if (port != tmpPort) {
+			String message = String.format("Port %s is already in use. What port would you like to use?", port);
 
-	        port = 0;
-	        while (port < 1 || port > 65535) {
-	            String result = wizard.promptForValueIfMissingWithDefault(message, null, null, String.valueOf(tmpPort));
-	            try {
-	                port = Integer.parseInt(result);
-	            } catch (NumberFormatException ignore) {}
-	            
-	            String.format("%s is not a valid port. What port would you like to use?", result);
-	        }
-	    }
+			port = 0;
+			while (port < 1 || port > 65535) {
+				String result = wizard.promptForValueIfMissingWithDefault(message, null, null, String.valueOf(tmpPort));
+				try {
+					port = Integer.parseInt(result);
+				} catch (NumberFormatException ignore) {}
+
+				String.format("%s is not a valid port. What port would you like to use?", result);
+			}
+		}
 	}
 
 	private void runInFork(Server server) throws MojoExecutionException, MojoFailureException {

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
@@ -131,19 +131,22 @@ public class Run extends AbstractTask {
 	}
 
 	private void validatePort() {
-		int tmpPort = port;
+	    int tmpPort = port;
 
-		tmpPort = serverHelper.findFreePort(tmpPort);
-		if (port != tmpPort) {
-			String message = String.format("Port %s is already in use. Would you like to use %s instead?", port, tmpPort);
-			boolean promptToChange = wizard.promptYesNo(message);
-			if (promptToChange) {
-				port = tmpPort;
-				return;
-			} else {
-				this.validatePort();
-			}
-		}
+	    tmpPort = serverHelper.findFreePort(tmpPort);
+	    if (port != tmpPort) {
+	        String message = String.format("Port %s is already in use. What port would you like to use?", port);
+
+	        port = 0;
+	        while (port < 1 || port > 65535) {
+	            String result = wizard.promptForValueIfMissingWithDefault(message, null, null, String.valueOf(tmpPort));
+	            try {
+	                port = Integer.parseInt(result);
+	            } catch (NumberFormatException ignore) {}
+	            
+	            String.format("%s is not a valid port. What port would you like to use?", result);
+	        }
+	    }
 	}
 
 	private void runInFork(Server server) throws MojoExecutionException, MojoFailureException {


### PR DESCRIPTION
Description of what I did:
I worked on an option where by when a port is taken while running openmrs SDK, the SDK should not only suggests un alternative port to be used but also  allow a user to specify a port they want to use. To achieve this I took the input to the wizard prompt and turn it into the port value which is returned by the value of the promptForValueIfMIssingWithDefault() function.

Ticket worked on:
https://issues.openmrs.org/projects/SDK/issues/SDK-222?filter=allopenissues