### PR TITLE
TRUNK-4830 Avoid running legacy liquibase changesets

### DIFF
--- a/maven-plugin/src/main/resources/openmrs-platform.sql
+++ b/maven-plugin/src/main/resources/openmrs-platform.sql
@@ -1770,6 +1770,19 @@ INSERT INTO `liquibasechangelog` VALUES ('0','bwolfe','liquibase-update-to-lates
 /*!40000 ALTER TABLE `liquibasechangelog` ENABLE KEYS */;
 UNLOCK TABLES;
 
+
+--
+-- Add missing references to two more change sets from `openmrs-core/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-1.9.x.xml` to the table `liquibasechangelog`.
+--
+-- openmrs-core/api uses Liquibase snapshots since 2.4.0 and without those references updating the OpenMRS database fails.
+--
+
+LOCK TABLES `liquibasechangelog` WRITE;
+/*!40000 ALTER TABLE `liquibasechangelog` DISABLE KEYS */;
+INSERT INTO `liquibasechangelog` VALUES ('20120529-2230','mvorobey','liquibase-schema-only.xml','2016-07-07 08:14:28',401,'EXECUTED',NULL,'Add Foreign Key Constraint','',NULL,'2.0.5'),('20120529-2231','mvorobey','liquibase-schema-only.xml','2016-07-07 08:14:28',402,'EXECUTED',NULL,'Add Foreign Key Constraint','',NULL,'2.0.5');
+/*!40000 ALTER TABLE `liquibasechangelog` ENABLE KEYS */;
+UNLOCK TABLES;
+
 --
 -- Table structure for table `liquibasechangeloglock`
 --


### PR DESCRIPTION
This pull request adds two records to the `liquibasechangelog` table.

Without those values updating the database with the new Liquibase snapshots introduced by 2.4.0-SNAPSHOT is failing.

Creating, starting and restarting servers was successfully tested for both OpenMRS 2.3.0 and 2.4.0-SNAPSHOT.