### PR TITLE
SDK-273 - Adds a step during the BuildDistro and Setup tasks that att…

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/BuildDistro.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/BuildDistro.java
@@ -17,7 +17,12 @@ import org.openmrs.maven.plugins.utility.DistroHelper;
 import org.openmrs.maven.plugins.utility.Project;
 import org.openmrs.maven.plugins.utility.SDKConstants;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 
@@ -255,12 +260,33 @@ public class BuildDistro extends AbstractTask {
 
     private void downloadOWAs(File targetDirectory, DistroProperties distroProperties, File owasDir) throws MojoExecutionException {
         List<Artifact> owas = distroProperties.getOwaArtifacts(distroHelper, targetDirectory);
-        OpenmrsBintray openmrsBintray = new OpenmrsBintray(getProxyFromSettings());
-
         if (!owas.isEmpty()) {
             wizard.showMessage("Downloading OWAs...\n");
             for (Artifact owa: owas) {
-                openmrsBintray.downloadOWA(owasDir, owa.getArtifactId(), owa.getVersion());
+                installOwa(owasDir, owa);
+            }
+        }
+    }
+
+    private void installOwa(File owasDir, Artifact owa) throws MojoExecutionException {
+        // Support existing Bintray artifacts
+        try {
+            OpenmrsBintray openmrsBintray = new OpenmrsBintray(getProxyFromSettings());
+            openmrsBintray.downloadOWA(owasDir, owa.getArtifactId(), owa.getVersion());
+        }
+        catch (Exception e) {
+            // If file is not found in bintray, and exception will be thrown.  Try to find it in Maven repo.
+            moduleInstaller.installModule(owa, owasDir.getAbsolutePath());
+            File downloadedFile = new File(owasDir, owa.getArtifactId() + "-" + owa.getVersion() + "." + owa.getType());
+            if (!downloadedFile.exists()) {
+                throw new MojoExecutionException("Unable to download OWA from Bintray or Maven", e);
+            }
+            File renamedFile = new File(owasDir, owa.getArtifactId() + OpenmrsBintray.OWA_PACKAGE_EXTENSION);
+            try {
+                FileUtils.moveFile(downloadedFile, renamedFile);
+            }
+            catch (IOException ioe) {
+                throw new MojoExecutionException("Unable to move OWA file to " + renamedFile, e);
             }
         }
     }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/bintray/OpenmrsBintray.java
@@ -28,8 +28,7 @@ public class OpenmrsBintray extends Bintray{
     public static final String OPENMRS_OMOD_REPO = "omod";
     public static final String OPENMRS_OWA_PREFIX = "openmrs-owa-";
     public static final String OPENMRS_MODULE_PREFIX = "openmrs-module-";
-
-    private static final String OWA_PACKAGE_EXTENSION = ".owa";
+    public static final String OWA_PACKAGE_EXTENSION = ".owa";
 
     public OpenmrsBintray(Proxy proxy) {
         super(proxy);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Artifact.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Artifact.java
@@ -23,6 +23,7 @@ public class Artifact {
     private String destFileName;
 
     public static final String GROUP_MODULE = "org.openmrs.module";
+    public static final String GROUP_OWA = "org.openmrs.owa";
     public static final String GROUP_WEB = "org.openmrs.web";
     public static final String GROUP_OPENMRS = "org.openmrs";
     public static final String GROUP_H2 = "com.h2database";

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/BaseSdkProperties.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/BaseSdkProperties.java
@@ -101,7 +101,7 @@ public abstract class BaseSdkProperties {
             String key = keyObject.toString();
             if (key.startsWith(TYPE_OWA + ".")) {
                 String artifactId = key.substring(TYPE_OWA.length() + 1);
-                artifacts.add(new Artifact(artifactId, getParam(key)));
+                artifacts.add(new Artifact(artifactId, getParam(key), Artifact.GROUP_OWA, Artifact.TYPE_ZIP));
             }
         }
         return artifacts;


### PR DESCRIPTION
…empts to download an owa from Maven if it fails to download from Bintray

@dkayiwa @ibacher and @mogoodrich - pinging you each on this, as I think we're going to be dealing with a number of Bintray related implications.

This isn't intending to be an end-all-be-all solution for fixing Bintray or OWA handling in the SDK, but this covers the two main use cases I am most concerned about in the PIH workflow, which is:

* Setting up a new SDK instance of our distribution, if it contains owas in the openmrs-distro.properties file, and having these OWAs installed into the owa directory as indicated (pulling from either Bintray or Maven).  This is the "Setup" task.

* Building a distribution zip for deployment to test/production servers, which uses the SDK maven plugin to pull down the war file, modules, and owas defined in openmrs-distro.properties so that they can be packaged up.  This is the "BuildDistro" task.

We likely need more extensive changes throughout the SDK.  But I don't want that job to delay these improvements, if possible.