### PR TITLE
SDK-275: Support module names with dashes

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Artifact.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/model/Artifact.java
@@ -99,12 +99,18 @@ public class Artifact {
 
     public String getDestFileName() {
         if (destFileName == null) {
-            String[] parts = artifactId.split("-");
+            String[] parts = StringUtils.reverse(artifactId).split("-", 2);
 
-            String id = parts[0];
-            // There is more than one dash in the artifactId
-            if (parts.length > 2) {
-                id = StringUtils.join(Arrays.copyOf(parts, parts.length-1), '-');
+            String id;
+            if (parts.length == 1) {
+                id = artifactId;
+            } else {
+                id = StringUtils.reverse(parts[1]);
+
+                String remainder = StringUtils.reverse(parts[0]);
+                if (!remainder.equals("omod")) {
+                    id += "-" + remainder;
+                }
             }
 
             return String.format(DEST_TEMPLATE, id, version, fileExtension);

--- a/maven-plugin/src/test/java/org/openmrs/maven/plugins/model/ArtifactTest.java
+++ b/maven-plugin/src/test/java/org/openmrs/maven/plugins/model/ArtifactTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ArtifactTest {
 
     @Test
-    public void testGetDestFileName() throws Exception{
+    public void testGetDestFileName() {
         Artifact nodashes = new Artifact("modulename-omod","1.4-SNAPSHOT");
         assertThat(nodashes.getDestFileName(), is("modulename-1.4-SNAPSHOT.jar"));
 
@@ -17,5 +17,8 @@ public class ArtifactTest {
 
         Artifact withdoubledashes = new Artifact("modulename-submodule-subsubmodule-omod","5.7.1");
         assertThat(withdoubledashes.getDestFileName(), is("modulename-submodule-subsubmodule-5.7.1.jar"));
+
+        Artifact withoutomod = new Artifact("modulename-anothername", "1.0.0");
+        assertThat(withoutomod.getDestFileName(), is("modulename-anothername-1.0.0.jar"));
     }
 }


### PR DESCRIPTION
This changes `getDestFileName()` to only remove "-omod" rather than whatever was at the end of the dash. This is useful for supporting OWAs (and other artefacts we may need to support).