### PR TITLE
SPA installer should handle array-type config parameters correctly

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/SetupIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/SetupIntegrationTest.java
@@ -164,6 +164,7 @@ public class SetupIntegrationTest extends AbstractSdkIntegrationTest {
         assertFilePresent(serverId + File.separator + "frontend" + File.separator + "openmrs-esm-patient-chart-app-3.0.0");
         String indexContents = FileUtils.readFileToString(new File(testDirectory.getAbsolutePath(), indexFilePath));
         assertThat(indexContents, containsString("apiUrl: \"notopenmrs\""));
+        assertThat(indexContents, containsString("configUrls: [\"foo\"]"));
 
         Server.setServersPath(testDirectory.getAbsolutePath());
         Server server = Server.loadServer(serverId);

--- a/integration-tests/src/test/resources/integration-test/openmrs-distro.properties
+++ b/integration-tests/src/test/resources/integration-test/openmrs-distro.properties
@@ -11,3 +11,4 @@ property.pih.default.config.default=shouldNotBeUsed
 spa.microfrontends.@openmrs/esm-login-app=3.1.0
 spa.microfrontends.@openmrs/esm-patient-chart-app=3.0.0
 spa.apiUrl=notopenmrs
+spa.configUrls=foo

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -19,6 +19,7 @@ import org.openmrs.maven.plugins.git.GitHelper;
 import org.openmrs.maven.plugins.utility.DockerHelper;
 import org.openmrs.maven.plugins.utility.Jira;
 import org.openmrs.maven.plugins.utility.ModuleInstaller;
+import org.openmrs.maven.plugins.utility.NodeHelper;
 import org.openmrs.maven.plugins.utility.OwaHelper;
 import org.openmrs.maven.plugins.utility.SpaInstaller;
 import org.openmrs.maven.plugins.utility.StatsManager;
@@ -190,7 +191,7 @@ public abstract class AbstractTask extends AbstractMojo {
             owaHelper = new OwaHelper(mavenSession, mavenProject, pluginManager, wizard);
         }
         if (spaInstaller == null) {
-            spaInstaller = new SpaInstaller(mavenProject, mavenSession, pluginManager, distroHelper);
+            spaInstaller = new SpaInstaller(distroHelper, new NodeHelper(mavenProject, mavenSession, pluginManager));
         }
         if(dockerHelper == null){
             dockerHelper = new DockerHelper(mavenProject, mavenSession, pluginManager, wizard);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -86,7 +86,7 @@ public class SpaInstaller {
     /**
      * Add a line from the properties file to the new JSON object. Creates nested objects as needed.
      * Known array-valued keys are parsed as comma-delimited arrays; e.g.,
-     *   `configUrl=qux` becomes `{ "configUrl": ["qux"] }` because `configUrl` is known to be array-valued
+     *   `configUrls=qux` becomes `{ "configUrls": ["qux"] }` because `configUrls` is known to be array-valued
      *
      * @param jsonObject the object being constructed
      * @param propertyKey

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -32,12 +32,10 @@ public class SpaInstaller {
 
     private DistroHelper distroHelper;
 
-    public SpaInstaller(MavenProject mavenProject,
-                        MavenSession mavenSession,
-                        BuildPluginManager pluginManager,
-                        DistroHelper distroHelper) {
+    public SpaInstaller(DistroHelper distroHelper,
+                        NodeHelper nodeHelper) {
         this.distroHelper = distroHelper;
-        this.nodeHelper = new NodeHelper(mavenProject, mavenSession, pluginManager);
+        this.nodeHelper = nodeHelper;
     }
 
     /**

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -85,9 +85,7 @@ public class SpaInstaller {
 
     /**
      * Add a line from the properties file to the new JSON object. Creates nested objects as needed.
-     * If the value contains commas, it is assumed to represent an array of strings. Known array-valued
-     * parameters are always parsed as arrays of strings. e.g.
-     *   `foo=bar,baz` becomes `{ "foo": ["bar", "baz"] }`
+     * Known array-valued keys are parsed as comma-delimited arrays; e.g.,
      *   `configUrl=qux` becomes `{ "configUrl": ["qux"] }` because `configUrl` is known to be array-valued
      *
      * @param jsonObject the object being constructed
@@ -101,7 +99,7 @@ public class SpaInstaller {
                 throw new RuntimeException(BAD_SPA_PROPERTIES_MESSAGE +
                         " Encountered this error processing a property containing the key '" + keys[0] + "' and with value " + value);
             }
-            if (value.contains(",") || "configUrls".equals(keys[0])) {
+            if ("configUrls".equals(keys[0])) {
                 JsonArray arr = new JsonArray();
                 for (String valueElement : value.split(",")) {
                     arr.add(valueElement);

--- a/maven-plugin/src/test/java/org/openmrs/maven/plugins/utility/SpaInstallerTest.java
+++ b/maven-plugin/src/test/java/org/openmrs/maven/plugins/utility/SpaInstallerTest.java
@@ -1,0 +1,68 @@
+package org.openmrs.maven.plugins.utility;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.it.util.ResourceExtractor;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.maven.plugins.model.DistroProperties;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpaInstallerTest {
+
+    SpaInstaller spaInstaller;
+
+    @Mock
+    DistroHelper distroHelper;
+
+    @Mock
+    NodeHelper nodeHelper;
+
+    File appDataDir;
+
+    @Before
+    public void setup() throws Exception{
+        appDataDir = new File(ResourceExtractor.simpleExtractResources(getClass(), "/test-tmp"), "server1");
+        appDataDir.mkdirs();
+        spaInstaller = new SpaInstaller(distroHelper, nodeHelper);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        appDataDir.delete();
+    }
+
+    @Test
+    public void spaInstall_shouldParseSingleConfigUrlCorrectly() throws MojoExecutionException, MojoFailureException, IOException {
+        Properties distroProperties = new Properties();
+        distroProperties.setProperty("spa.configUrls", "foo");
+        spaInstaller.installFromDistroProperties(appDataDir, new DistroProperties(distroProperties));
+        File spaConfigFile = new File(appDataDir, "spa-build-config.json");
+        String spaConfig = FileUtils.readFileToString(spaConfigFile);
+        Assert.assertThat(spaConfig, Matchers.containsString("\"configUrls\":[\"foo\"]"));
+    }
+
+    @Test
+    public void spaInstall_shouldParseConfigUrlsCorrectly() throws MojoExecutionException, MojoFailureException, IOException {
+        Properties distroProperties = new Properties();
+        distroProperties.setProperty("spa.configUrls", "foo,bar,baz");
+        spaInstaller.installFromDistroProperties(appDataDir, new DistroProperties(distroProperties));
+        File spaConfigFile = new File(appDataDir, "spa-build-config.json");
+        String spaConfig = FileUtils.readFileToString(spaConfigFile);
+        Assert.assertThat(spaConfig, Matchers.containsString("\"configUrls\":[\"foo\",\"bar\",\"baz\"]"));
+    }
+}

--- a/maven-plugin/src/test/resources/test-tmp/.gitignore
+++ b/maven-plugin/src/test/resources/test-tmp/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This adds support for SPA parameters that take array arguments. Right now this is just `configUrls`.