### PR TITLE
Using try-with-resources is more concise and safer way of managing resources

### DIFF
--- a/sdk-commons/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
+++ b/sdk-commons/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.openmrs.maven.plugins.utility.DistroHelper;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -192,18 +193,15 @@ public class DistroProperties extends BaseSdkProperties {
     }
 
     public void saveTo(File path) throws MojoExecutionException {
-        FileOutputStream out = null;
-        try {
-            out = new FileOutputStream(new File(path, DISTRO_FILE_NAME));
-            SortedProperties sortedProperties = new SortedProperties();
-            sortedProperties.putAll(properties);
-            sortedProperties.store(out, null);
-        }
-        catch (IOException e) {
+       // automatically close the stream after the try block finishes executing
+       try (FileOutputStream out = new FileOutputStream(new File(path, DISTRO_FILE_NAME))) { 
+        SortedProperties sortedProperties = new SortedProperties();
+        sortedProperties.putAll(properties);
+        sortedProperties.store(out, null);
+        } catch (FileNotFoundException e) { // catch if the file not found
+            throw new MojoExecutionException("File not found", e);
+        } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage());
-        }
-        finally {
-            IOUtils.closeQuietly(out);
         }
     }
 


### PR DESCRIPTION
[1] converting normal try to try-with-resources
[2] add 1 more exception for file if not finding the path