### PR TITLE
Sdk 304: Optimising setModuleProperties method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ For more details visit [the project page](https://wiki.openmrs.org/display/docs/
 
 ## Requirements
  * Maven 3.x
+    
+    The Latest Version of Apache Maven may Collide with the JDK 8. Try using Apache Maven 3.6.3
+
+
+ * JDK 8
+
  
 ## Installation
+* Maven 3.x 
+   
+Mac:
+   Using homebrew Run `brew install maven` or you can manually download and install the archived version of Apache Maven from [Here (Maven 3.6.3)](https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/)
+* JDK 8
+
+Mac: First Run `brew tap homebrew/cask-versions` and then ` brew install --cask temurin8`
+
 In order to install the latest version of the sdk run: <br/>
 
 `mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:setup-sdk`

--- a/sdk-commons/src/main/java/org/openmrs/maven/plugins/model/BaseSdkProperties.java
+++ b/sdk-commons/src/main/java/org/openmrs/maven/plugins/model/BaseSdkProperties.java
@@ -227,14 +227,13 @@ public abstract class BaseSdkProperties {
 
     public void setModuleProperties(Artifact newModule) {
         newModule = stripArtifactId(newModule);
-        if(!newModule.getGroupId().equals(Artifact.GROUP_MODULE)){
+        if (!Artifact.GROUP_MODULE.equals(newModule.getGroupId())) {
             setCustomModuleGroupId(newModule);
         }
-        if(!newModule.getType().equals(TYPE_JAR)){
+        if (!TYPE_JAR.equals(newModule.getType())) {
             setCustomModuleType(newModule);
         }
         setModule(newModule);
-
     }
 
     public void removeModuleProperties(Artifact artifact) {


### PR DESCRIPTION
Instead of calling the equals() method on the groupId and type fields of the newModule object, I am calling it on the constant values Artifact.GROUP_MODULE and TYPE_JAR. This is because constants are more likely to be interned and thus comparison with them may be faster than comparison with variables.