### PR TITLE
Removing memory-related parameters from Maven opts

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Run.java
@@ -168,7 +168,6 @@ public class Run extends AbstractServerTask {
 		}
 
 		mavenOpts = adjustXmxToAtLeast(mavenOpts, 768);
-		mavenOpts = adjustMaxPermSizeToAtLeast(mavenOpts, 512);
 
 		if (server.hasWatchedProjects() && isWatchApi()) {
 			mavenOpts +=
@@ -176,7 +175,7 @@ public class Run extends AbstractServerTask {
 		}
 
 		mavenOpts = setDebugPort(mavenOpts, server);
-		
+
 		Properties properties = new Properties();
 		properties.put("serverId", server.getServerId());
 		if (port != null) {


### PR DESCRIPTION
reference: https://talk.openmrs.org/t/manual-installation-build-tests-fail-at-openmrs-api/40060/12