### PR TITLE
Adding an error if the server path contains a space.

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -681,6 +681,10 @@ public class Setup extends AbstractServerTask {
 			throw new MojoExecutionException(
 					"Cannot create server: directory with name " + serverDir.getName() + " already exists");
 		}
+		else if (serverDir.getAbsolutePath().contains(" ")) {
+			throw new MojoExecutionException("Cannot create server: The server path " + serverDir.getAbsolutePath() +
+					" contains a space. Please make sure your server path does not include any spaces.");
+		}
 
 		server.setServerDirectory(serverDir);
 		serverDir.mkdir();


### PR DESCRIPTION
Setting up servers is problematic when the server file path contains spaces. So this adds an error message for server directories with spaces.