### PR TITLE
O3-3439: Add exclusions to distro.properties

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/maven/plugins/AddExclusionIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/maven/plugins/AddExclusionIntegrationTest.java
@@ -1,0 +1,48 @@
+package org.openmrs.maven.plugins;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.maven.plugins.model.DistroProperties;
+import org.openmrs.maven.plugins.utility.DistroHelper;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AddExclusionIntegrationTest extends AbstractSdkIntegrationTest {
+
+    private String distroFile;
+
+    private DistroProperties originalProperties;
+
+    @Before
+    public void setUp() {
+        distroFile = testDirectory + File.separator + "openmrs-distro.properties";
+        originalProperties = DistroHelper.getDistroPropertiesFromFile(new File(distroFile));
+    }
+
+    @Test
+    public void shouldAddExclusion() throws Exception {
+        DistroProperties distroProperties = DistroHelper.getDistroPropertiesFromFile(new File(distroFile));
+        assertNotNull(distroProperties);
+        assertFalse(distroProperties.getExclusions().contains("omod.uicommons"));
+
+        addTaskParam("distro", distroFile);
+        addTaskParam("property", "omod.uicommons");
+        executeTask("exclusion");
+
+        assertSuccess();
+        distroProperties = DistroHelper.getDistroPropertiesFromFile(new File(distroFile));
+        assertTrue(distroProperties.getExclusions().contains("omod.uicommons"));
+    }
+
+
+    @After
+    public void reset() throws MojoExecutionException {
+        originalProperties.saveTo(new File(distroFile).getParentFile());
+    }
+}

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/AddExclusion.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/AddExclusion.java
@@ -1,0 +1,82 @@
+package org.openmrs.maven.plugins;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.openmrs.maven.plugins.model.Artifact;
+import org.openmrs.maven.plugins.model.DistroProperties;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mojo(name = "exclusion", requiresProject = false)
+public class AddExclusion extends AbstractTask {
+
+    /**
+     * Path to the openmrs-distro.properties file to modify
+     */
+    @Parameter(property = "distro")
+    private String distro;
+
+    /**
+     * Name of the property you want to exclude
+     */
+    @Parameter(property = "property")
+    private String property;
+
+
+    @Override
+    public void executeTask() throws MojoExecutionException, MojoFailureException {
+        if (distro == null) {
+            File userDir = new File(System.getProperty("user.dir"));
+            File distroFile = new File(userDir, DistroProperties.DISTRO_FILE_NAME);
+            if (distroFile.exists()) {
+                distro = distroFile.getAbsolutePath();
+            } else {
+                throw new MojoFailureException("Please specify a distro file");
+            }
+        }
+
+        DistroProperties originalDistroProperties = null;
+
+        if (StringUtils.isNotBlank(distro)) {
+            originalDistroProperties = distroHelper.resolveDistroPropertiesForStringSpecifier(distro, versionsHelper);
+
+        }
+
+        if (originalDistroProperties == null) {
+            throw new MojoFailureException("Invalid distro file");
+        }
+
+        Artifact distroArtifact = originalDistroProperties.getParentArtifact();
+        if (StringUtils.isNotBlank(distroArtifact.getArtifactId()) && StringUtils.isNotBlank(distroArtifact.getGroupId()) && StringUtils.isNotBlank(distroArtifact.getVersion())) {
+            DistroProperties distroProperties = distroHelper.resolveParentArtifact(distroArtifact, new File(distro).getParentFile(), originalDistroProperties, null);
+            if (StringUtils.isBlank(property)) {
+                List<String> currentExclusions = distroProperties.getExclusions();
+                List<String> options = distroProperties.getPropertyNames().stream().filter(prop -> !currentExclusions.contains(prop)).collect(Collectors.toList());
+                property = wizard.promptForMissingValueWithOptions("Enter the property you want to exclude",
+                        null, null, options);
+            } else {
+                if (!distroProperties.getPropertyNames().contains(property)) {
+                    wizard.showWarning("The property is not included in the parent distro");
+                }
+            }
+
+        } else {
+            wizard.showWarning("This distro properties file does not contain a valid parent distro");
+            if (StringUtils.isBlank(property)) {
+                property = wizard.promptForValueIfMissing(null, "property to exclude");
+                if (StringUtils.isBlank(property)) {
+                    throw new MojoFailureException("Invalid property name");
+                }
+            }
+        }
+        originalDistroProperties.addExclusion(property);
+        wizard.showMessage(property + " is added to exclusions");
+        originalDistroProperties.saveTo(new File(distro).getParentFile());
+    }
+
+}

--- a/sdk-commons/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
+++ b/sdk-commons/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
@@ -282,6 +282,16 @@ public class DistroProperties extends BaseSdkProperties {
         properties.remove(property);
     }
 
+    public void addExclusion(String exclusion) {
+        String exclusions = getParam("exclusions");
+        if (exclusions == null){
+            properties.setProperty("exclusions", exclusion);
+            return;
+        }
+
+        properties.setProperty("exclusions", exclusions + "," + exclusion);
+    }
+
     private String getPlaceholderKey(String string){
         int startIndex = string.indexOf("${")+2;
         int endIndex = string.indexOf("}", startIndex);

--- a/sdk-commons/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/sdk-commons/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -325,6 +325,11 @@ public class DefaultWizard implements Wizard {
 		writer.println("\n[ERROR]" + textToShow);
 	}
 
+	@Override
+	public void showWarning(String message) {
+		writer.println("\n[WARNING]" + message);
+	}
+
 	/**
 	 * Prompt for a value if it not set, and default value is NOT set
 	 *

--- a/sdk-commons/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/sdk-commons/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -51,6 +51,8 @@ public interface Wizard {
 
     void showError(String message);
 
+    void showWarning(String message);
+
     String promptForValueIfMissingWithDefault(String message, String value, String parameterName, String defValue)
             throws MojoExecutionException;
 


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'SDK-306: Integrated Micro Frontend Tooling Setup in OpenMRS SDK' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

This adds a plugin that allows users to manipulate a distro.properties file by removing exclusions.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one, so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://openmrs.atlassian.net/browse/O3-3439

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task, please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean install` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute the above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
