### PR TITLE
O3-3639: SDK to rebuild frontend with multiple config files

### DIFF
--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -12,6 +12,7 @@ import org.openmrs.maven.plugins.model.Artifact;
 import org.openmrs.maven.plugins.model.DistroProperties;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.model.Version;
+import org.openmrs.maven.plugins.utility.ContentHelper;
 import org.openmrs.maven.plugins.utility.DistroHelper;
 import org.openmrs.maven.plugins.model.Project;
 import org.openmrs.maven.plugins.utility.SDKConstants;
@@ -123,6 +124,7 @@ public class Deploy extends AbstractServerTask {
 			if (artifact != null) {
 				deployOpenmrsFromDir(server, artifact);
 			} else if (distroProperties != null) {
+				ContentHelper.setModuleInstaller(moduleInstaller);
 				serverUpgrader.upgradeToDistro(server, distroProperties, ignorePeerDependencies, overrideReuseNodeCache);
 			} else if (checkCurrentDirForModuleProject()) {
 				deployModule(groupId, artifactId, version, server);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/Deploy.java
@@ -124,7 +124,6 @@ public class Deploy extends AbstractServerTask {
 			if (artifact != null) {
 				deployOpenmrsFromDir(server, artifact);
 			} else if (distroProperties != null) {
-				ContentHelper.setModuleInstaller(moduleInstaller);
 				serverUpgrader.upgradeToDistro(server, distroProperties, ignorePeerDependencies, overrideReuseNodeCache);
 			} else if (checkCurrentDirForModuleProject()) {
 				deployModule(groupId, artifactId, version, server);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -19,8 +20,9 @@ public class ContentHelper {
 	
 	public static final String FRONTEND_CONFIG_FOLDER = Paths.get("configs", "frontend_config").toString();
 	public static final String BACKEND_CONFIG_FOLDER = Paths.get("configs", "backend_config").toString();
+	private static ModuleInstaller moduleInstaller;
 	
-	public static void downloadContent(Artifact contentArtifact, ModuleInstaller moduleInstaller, File targetDir) throws MojoExecutionException {
+	private static File unpackArtifact(Artifact contentArtifact) throws MojoExecutionException {		
 		String artifactId = contentArtifact.getArtifactId();
 		// create a temporary artifact folder
 		File sourceDir;
@@ -31,12 +33,11 @@ public class ContentHelper {
 		}
 
 		moduleInstaller.installAndUnpackModule(contentArtifact, sourceDir.getAbsolutePath());
-		moveBackendConfig(artifactId, sourceDir, targetDir);
-
-		FileUtils.deleteQuietly(sourceDir);
+		return sourceDir;		
 	}
-	
-	private static void moveBackendConfig(String artifactId, File sourceDir, File targetDir) throws MojoExecutionException {
+		
+	private static void moveBackendConfig(Artifact contentArtifact, ModuleInstaller moduleInstaller, File targetDir) throws MojoExecutionException {
+		File sourceDir = unpackArtifact (contentArtifact);
 		try {				
 			File backendConfigFiles = sourceDir.toPath().resolve(BACKEND_CONFIG_FOLDER).toFile();
 			Path targetPath = targetDir.toPath().toAbsolutePath();
@@ -45,21 +46,43 @@ public class ContentHelper {
 				File[] configDirectories =  backendConfigFiles.listFiles(File::isDirectory);
 				if (configDirectories != null) {
 					for (File config : configDirectories) {
-						Path destDir = targetPath.resolve(config.getName()).resolve(artifactId);
+						Path destDir = targetPath.resolve(config.getName()).resolve(contentArtifact.getArtifactId());
 						Files.createDirectories(destDir);
 
 						//copy config files to the matching configuration folder
 						FileUtils.copyDirectory(config, destDir.toFile());
 					}
 				}
-			}
+			}			
 		}
 		catch (IOException e) {
 			throw new MojoExecutionException("Error copying backend configuration: " + e.getMessage(), e);
 		}
+		FileUtils.deleteQuietly(sourceDir);
 	}
 	
-	public static void downloadAndMoveContentBackendConfig(File serverDirectory, DistroProperties distroProperties, ModuleInstaller moduleInstaller, Wizard wizard) throws MojoExecutionException {
+	public static List<File> extractAndGetAllContentFrontendConfigs(Artifact contentArtifact) throws MojoExecutionException {
+		File sourceDir = unpackArtifact (contentArtifact);
+		List<File> configFiles = new ArrayList<>();		
+		File frontendConfigFiles = sourceDir.toPath().resolve(FRONTEND_CONFIG_FOLDER).toFile();
+
+		if (frontendConfigFiles.exists() && frontendConfigFiles.isDirectory()) {
+		    File[] files = frontendConfigFiles.listFiles();		    
+		    if (files != null) {
+		        for (File file : files) {
+		            if (file.isFile()) {
+		                configFiles.add(file);
+		            }
+		        }
+		    }
+		} else {
+			throw new MojoExecutionException("Error copying Frontend configuration");
+		}
+		return configFiles;
+	}
+	
+	public static void downloadAndMoveContentBackendConfig(File serverDirectory, DistroProperties distroProperties, ModuleInstaller moduleInst, Wizard wizard) throws MojoExecutionException {
+		moduleInstaller = moduleInst;
 		if (distroProperties != null) {
 			File targetDir = new File(serverDirectory, SDKConstants.OPENMRS_SERVER_CONFIGURATION);				
 			List<Artifact> contents = distroProperties.getContentArtifacts();
@@ -67,9 +90,28 @@ public class ContentHelper {
 			if (contents != null) {
 				for (Artifact content : contents) {
 					wizard.showMessage("Downloading Content: " + content + "\n");
-					ContentHelper.downloadContent(content, moduleInstaller, targetDir);
+					moveBackendConfig(content, moduleInstaller, targetDir);
 				}
 			}			
 		}
+		
+	}	
+	
+	public static List<File> collectFrontendConfigs(DistroProperties distroProperties) throws MojoExecutionException {
+		System.out.println("------------------------------------------collectFrontendConfigs");
+		List<File> allConfigFiles = new ArrayList<File>();	
+		if (distroProperties != null) {			
+			List<Artifact> contents = distroProperties.getContentArtifacts();								
+			if (contents != null) {
+				System.out.println("------------------------------------------collectFrontendConfigs--1");
+				for (Artifact contentArtifact : contents) {		
+					System.out.println("------------------------------------------collectFrontendConfigs--2");
+					allConfigFiles.addAll(extractAndGetAllContentFrontendConfigs(contentArtifact));
+					System.out.println("------------------------------------------collectFrontendConfigs--3");
+				}
+			}			
+		}
+		System.out.println("\n\n" +allConfigFiles.size());
+		return allConfigFiles;		
 	}	
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
@@ -31,7 +31,6 @@ public class ContentHelper {
 			throw new MojoExecutionException("Exception while trying to create temporary directory", e);
 		}
 		
-		// Ensure moduleInstaller is set before calling this
 		if (moduleInstaller == null) {
 			throw new MojoExecutionException("ModuleInstaller is not initialized.");
 		}
@@ -113,8 +112,7 @@ public class ContentHelper {
 		return allConfigFiles;		
 	}
 
-	public static String assembleWithFrontendConfig(String program, File buildTargetDir, List<File> configFiles, File spaConfigFile) {
-		// TODO: Implement this method
-		return null;
-	}	
+	public static void setModuleInstaller(ModuleInstaller modulInst) {
+		moduleInstaller = modulInst;
+	}
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
@@ -72,9 +72,9 @@ public class ContentHelper {
 		    File[] files = frontendConfigFiles.listFiles();		    
 		    if (files != null) {
 		        for (File file : files) {
-		            if (file.isFile()) {
-		                configFiles.add(file);
-		            }
+		        	if (file.isFile() && file.length() > 5) { 
+	                    configFiles.add(file);
+	                }
 		        }
 		    }
 		} else {

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.openmrs.maven.plugins.model.Artifact;
@@ -16,103 +17,96 @@ import org.openmrs.maven.plugins.model.DistroProperties;
  * This class downloads and moves content backend config to respective configuration folders.
  */
 public class ContentHelper {
-	
-	public static final String FRONTEND_CONFIG_FOLDER = Paths.get("configs", "frontend_config").toString();
-	public static final String BACKEND_CONFIG_FOLDER = Paths.get("configs", "backend_config").toString();
-	private static ModuleInstaller moduleInstaller;
-	
-	private static File unpackArtifact(Artifact contentArtifact) throws MojoExecutionException {		
-		String artifactId = contentArtifact.getArtifactId();
-		// create a temporary artifact folder
-		File sourceDir;
-		try {
-			sourceDir = Files.createTempDirectory("openmrs-sdk-" + artifactId + "-").toFile();
-		} catch (IOException e) {
-			throw new MojoExecutionException("Exception while trying to create temporary directory", e);
-		}
-		
-		if (moduleInstaller == null) {
-			throw new MojoExecutionException("ModuleInstaller is not initialized.");
-		}
-		moduleInstaller.installAndUnpackModule(contentArtifact, sourceDir.getAbsolutePath());
-		return sourceDir;		
-	}
-		
-	private static void moveBackendConfig(Artifact contentArtifact, File targetDir) throws MojoExecutionException {
-		File sourceDir = unpackArtifact(contentArtifact);
-		try {				
-			File backendConfigFiles = sourceDir.toPath().resolve(BACKEND_CONFIG_FOLDER).toFile();
-			Path targetPath = targetDir.toPath().toAbsolutePath();
 
-			if (backendConfigFiles.exists()) {
-				File[] configDirectories = backendConfigFiles.listFiles(File::isDirectory);
-				if (configDirectories != null) {
-					for (File config : configDirectories) {
-						Path destDir = targetPath.resolve(config.getName()).resolve(contentArtifact.getArtifactId());
-						Files.createDirectories(destDir);
+    public static final String FRONTEND_CONFIG_FOLDER = Paths.get("configs", "frontend_config").toString();
+    public static final String BACKEND_CONFIG_FOLDER = Paths.get("configs", "backend_config").toString();
 
-						// Copy config files to the matching configuration folder
-						FileUtils.copyDirectory(config, destDir.toFile());
-					}
-				}
-			}			
-		} catch (IOException e) {
-			throw new MojoExecutionException("Error copying backend configuration: " + e.getMessage(), e);
-		} finally {
-			FileUtils.deleteQuietly(sourceDir);
-		}
-	}
-	
-	public static List<File> extractAndGetAllContentFrontendConfigs(Artifact contentArtifact) throws MojoExecutionException {
-		File sourceDir = unpackArtifact(contentArtifact);
-		List<File> configFiles = new ArrayList<>();		
-		File frontendConfigFiles = sourceDir.toPath().resolve(FRONTEND_CONFIG_FOLDER).toFile();
+    private static File unpackArtifact(Artifact contentArtifact, ModuleInstaller moduleInstaller) throws MojoExecutionException {
+        String artifactId = contentArtifact.getArtifactId();
+        // create a temporary artifact folder
+        File sourceDir;
+        try {
+            sourceDir = Files.createTempDirectory("openmrs-sdk-" + artifactId).toFile();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Exception while trying to create temporary directory", e);
+        }
 
-		if (frontendConfigFiles.exists() && frontendConfigFiles.isDirectory()) {
-		    File[] files = frontendConfigFiles.listFiles();		    
-		    if (files != null) {
-		        for (File file : files) {
-		        	if (file.isFile() && file.length() > 5) { 
-	                    configFiles.add(file);
-	                }
-		        }
-		    }
-		} else {
-			throw new MojoExecutionException("Error: Frontend configuration folder not found.");
-		}
-		return configFiles;
-	}
-	
-	// This method now sets the static moduleInstaller
-	public static void downloadAndMoveContentBackendConfig(File serverDirectory, DistroProperties distroProperties, ModuleInstaller moduleInst, Wizard wizard) throws MojoExecutionException {
-		moduleInstaller = moduleInst;  // Set the static variable
-		if (distroProperties != null) {
-			File targetDir = new File(serverDirectory, SDKConstants.OPENMRS_SERVER_CONFIGURATION);				
-			List<Artifact> contents = distroProperties.getContentArtifacts();
-								
-			if (contents != null) {
-				for (Artifact content : contents) {
-					wizard.showMessage("Downloading Content: " + content + "\n");
-					moveBackendConfig(content, targetDir);
-				}
-			}			
-		}
-	}	
-	
-	public static List<File> collectFrontendConfigs(DistroProperties distroProperties) throws MojoExecutionException {		
-		List<File> allConfigFiles = new ArrayList<>();	
-		if (distroProperties != null) {			
-			List<Artifact> contents = distroProperties.getContentArtifacts();								
-			if (contents != null) {				
-				for (Artifact contentArtifact : contents) {						
-					allConfigFiles.addAll(extractAndGetAllContentFrontendConfigs(contentArtifact));					
-				}
-			}			
-		}
-		return allConfigFiles;		
-	}
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(sourceDir)));
 
-	public static void setModuleInstaller(ModuleInstaller modulInst) {
-		moduleInstaller = modulInst;
-	}
+        moduleInstaller.installAndUnpackModule(contentArtifact, sourceDir.getAbsolutePath());
+        return sourceDir;
+    }
+
+    private static void moveBackendConfig(Artifact contentArtifact, File targetDir, ModuleInstaller moduleInstaller) throws MojoExecutionException {
+        File sourceDir = unpackArtifact(contentArtifact, moduleInstaller);
+        try {
+            File backendConfigFiles = sourceDir.toPath().resolve(BACKEND_CONFIG_FOLDER).toFile();
+            Path targetPath = targetDir.toPath().toAbsolutePath();
+
+            if (backendConfigFiles.exists()) {
+                File[] configDirectories = backendConfigFiles.listFiles(File::isDirectory);
+                if (configDirectories != null) {
+                    for (File config : configDirectories) {
+                        Path destDir = targetPath.resolve(config.getName()).resolve(contentArtifact.getArtifactId());
+                        Files.createDirectories(destDir);
+
+                        // Copy config files to the matching configuration folder
+                        FileUtils.copyDirectory(config, destDir.toFile());
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error copying backend configuration: " + e.getMessage(), e);
+        } finally {
+            FileUtils.deleteQuietly(sourceDir);
+        }
+    }
+
+    public static List<File> extractAndGetAllContentFrontendConfigs(Artifact contentArtifact, ModuleInstaller moduleInstaller) throws MojoExecutionException {
+        File sourceDir = unpackArtifact(contentArtifact, moduleInstaller);
+        List<File> configFiles = new ArrayList<>();
+        File frontendConfigFiles = sourceDir.toPath().resolve(FRONTEND_CONFIG_FOLDER).toFile();
+
+        if (frontendConfigFiles.exists() && frontendConfigFiles.isDirectory()) {
+            File[] files = frontendConfigFiles.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isFile() && file.length() > 5) {
+                        configFiles.add(file);
+                    }
+                }
+            }
+        } else {
+            throw new MojoExecutionException("Error: Frontend configuration folder not found.");
+        }
+        return configFiles;
+    }
+
+    // This method now sets the static moduleInstaller
+    public static void downloadAndMoveContentBackendConfig(File serverDirectory, DistroProperties distroProperties, ModuleInstaller moduleInstaller, Wizard wizard) throws MojoExecutionException {
+        if (distroProperties != null) {
+            File targetDir = new File(serverDirectory, SDKConstants.OPENMRS_SERVER_CONFIGURATION);
+            List<Artifact> contents = distroProperties.getContentArtifacts();
+
+            if (contents != null) {
+                for (Artifact content : contents) {
+                    wizard.showMessage("Downloading Content: " + content + "\n");
+                    moveBackendConfig(content, targetDir, moduleInstaller);
+                }
+            }
+        }
+    }
+
+    public static List<File> collectFrontendConfigs(DistroProperties distroProperties, ModuleInstaller moduleInstaller) throws MojoExecutionException {
+        List<File> allConfigFiles = new ArrayList<>();
+        if (distroProperties != null) {
+            List<Artifact> contents = distroProperties.getContentArtifacts();
+            if (contents != null) {
+                for (Artifact contentArtifact : contents) {
+                    allConfigFiles.addAll(extractAndGetAllContentFrontendConfigs(contentArtifact, moduleInstaller));
+                }
+            }
+        }
+        return allConfigFiles;
+    }
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/ContentHelper.java
@@ -97,21 +97,16 @@ public class ContentHelper {
 		
 	}	
 	
-	public static List<File> collectFrontendConfigs(DistroProperties distroProperties) throws MojoExecutionException {
-		System.out.println("------------------------------------------collectFrontendConfigs");
+	public static List<File> collectFrontendConfigs(DistroProperties distroProperties) throws MojoExecutionException {		
 		List<File> allConfigFiles = new ArrayList<File>();	
 		if (distroProperties != null) {			
 			List<Artifact> contents = distroProperties.getContentArtifacts();								
-			if (contents != null) {
-				System.out.println("------------------------------------------collectFrontendConfigs--1");
-				for (Artifact contentArtifact : contents) {		
-					System.out.println("------------------------------------------collectFrontendConfigs--2");
-					allConfigFiles.addAll(extractAndGetAllContentFrontendConfigs(contentArtifact));
-					System.out.println("------------------------------------------collectFrontendConfigs--3");
+			if (contents != null) {				
+				for (Artifact contentArtifact : contents) {						
+					allConfigFiles.addAll(extractAndGetAllContentFrontendConfigs(contentArtifact));					
 				}
 			}			
 		}
-		System.out.println("\n\n" +allConfigFiles.size());
 		return allConfigFiles;		
 	}	
 }

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -95,9 +95,9 @@ public class SpaInstaller {
 			String program = "openmrs@" + coreVersion;
 			String legacyPeerDeps = ignorePeerDependencies ? "--legacy-peer-deps" : "";
 			// print frontend tool version number
-			nodeHelper.runNpx(String.format("%s --version", program), legacyPeerDeps);			
-			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);
+			nodeHelper.runNpx(String.format("%s --version", program), legacyPeerDeps);
 			
+			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);			
 			if (configFiles.isEmpty()) {
 				nodeHelper.runNpx(
 					String.format("%s assemble --target %s --mode config --config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);
@@ -105,6 +105,7 @@ public class SpaInstaller {
                 String assembleCommand = assembleWithFrontendConfig(program, buildTargetDir, configFiles, spaConfigFile); 
                 nodeHelper.runNpx(assembleCommand, legacyPeerDeps); 
 			}
+			
 			nodeHelper.runNpx(
 				String.format("%s build --target %s --build-config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -96,16 +96,14 @@ public class SpaInstaller {
 			// print frontend tool version number
 			nodeHelper.runNpx(String.format("%s --version", program), legacyPeerDeps);
 			
-			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);		
-			
-			if (configFiles.isEmpty()) {				
-				nodeHelper.runNpx(
-					String.format("%s assemble --target %s --mode config --config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);
-			}	else {				
-                String assembleCommand = assembleWithFrontendConfig(program, buildTargetDir, configFiles, spaConfigFile); 
-                nodeHelper.runNpx(assembleCommand, legacyPeerDeps); 
+			if (distroProperties.getContentArtifacts().isEmpty()) {				
+				nodeHelper.runNpx(String.format("%s assemble --target %s --mode config --config %s", program, buildTargetDir,
+				    spaConfigFile), legacyPeerDeps);				
+			} else {
+				List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);
+				String assembleCommand = assembleWithFrontendConfig(program, buildTargetDir, configFiles, spaConfigFile);
+				nodeHelper.runNpx(assembleCommand, legacyPeerDeps);
 			}
-			
 			nodeHelper.runNpx(
 				String.format("%s build --target %s --build-config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);
 

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -98,8 +98,7 @@ public class SpaInstaller {
 			
 			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);		
 			
-			if (!configFiles.isEmpty()) {
-				System.out.println("---------------SHOULD NOT SEE THIS-----------------------------" + configFiles.size());
+			if (configFiles.isEmpty()) {				
 				nodeHelper.runNpx(
 					String.format("%s assemble --target %s --mode config --config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);
 			}	else {				

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -95,10 +95,9 @@ public class SpaInstaller {
 			String program = "openmrs@" + coreVersion;
 			String legacyPeerDeps = ignorePeerDependencies ? "--legacy-peer-deps" : "";
 			// print frontend tool version number
-			nodeHelper.runNpx(String.format("%s --version", program), legacyPeerDeps);
-			System.out.println("------------------------------------------------------------------\n\n");
+			nodeHelper.runNpx(String.format("%s --version", program), legacyPeerDeps);			
 			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);
-			System.out.println("------------------------------------------------------------------" + configFiles.size());
+			
 			if (configFiles.isEmpty()) {
 				nodeHelper.runNpx(
 					String.format("%s assemble --target %s --mode config --config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/SpaInstaller.java
@@ -33,7 +33,7 @@ public class SpaInstaller {
 	
 	static final String NPM_VERSION = "8.5.5";
 	
-	static final String BUILD_TARGET_DIR = "frontend";
+	static final String BUILD_TARGET_DIR = "frontend";	
 	
 	private final NodeHelper nodeHelper;
 	
@@ -65,8 +65,7 @@ public class SpaInstaller {
 		// We find all the lines in distro properties beginning with `spa` and convert these
 		// into a JSON structure. This is passed to the frontend build tool.
 		// If no SPA elements are present in the distro properties, the SPA is not installed.
-		Map<String, String> spaProperties = distroProperties.getSpaProperties(distroHelper, appDataDir);
-
+		Map<String, String> spaProperties = distroProperties.getSpaProperties(distroHelper, appDataDir);		
 		// Three of these properties are not passed to the build tool, but are used to specify the build execution itself
 		String coreVersion = spaProperties.remove("core");
 		if (coreVersion == null) {
@@ -80,7 +79,7 @@ public class SpaInstaller {
 		if (npmVersion == null) {
 			npmVersion = NPM_VERSION;
 		}
-
+		
 		if (!spaProperties.isEmpty()) {
 			Map<String, Object> spaConfigJson = convertPropertiesToJSON(spaProperties);
 
@@ -92,16 +91,18 @@ public class SpaInstaller {
 			nodeHelper.installNodeAndNpm(nodeVersion, npmVersion, reuseNodeCache);
 			File buildTargetDir = new File(appDataDir, BUILD_TARGET_DIR);
 
-			String program = "openmrs@" + coreVersion;
+			String program = "openmrs@" + "5.8.0";
 			String legacyPeerDeps = ignorePeerDependencies ? "--legacy-peer-deps" : "";
 			// print frontend tool version number
 			nodeHelper.runNpx(String.format("%s --version", program), legacyPeerDeps);
 			
-			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);			
-			if (configFiles.isEmpty()) {
+			List<File> configFiles = ContentHelper.collectFrontendConfigs(distroProperties);		
+			
+			if (!configFiles.isEmpty()) {
+				System.out.println("---------------SHOULD NOT SEE THIS-----------------------------" + configFiles.size());
 				nodeHelper.runNpx(
 					String.format("%s assemble --target %s --mode config --config %s", program, buildTargetDir, spaConfigFile), legacyPeerDeps);
-			} else {
+			}	else {				
                 String assembleCommand = assembleWithFrontendConfig(program, buildTargetDir, configFiles, spaConfigFile); 
                 nodeHelper.runNpx(assembleCommand, legacyPeerDeps); 
 			}


### PR DESCRIPTION
Issue I worked on
see https://openmrs.atlassian.net/browse/O3-3639

was able to add --config-file parameter 

Running 'npm --legacy-peer-deps --cache=/tmp/openmrs-sdk-node11062473255982918384/npm-cache exec -- openmrs@5.8.0 assemble --target /scicomp/home-pure/test/openmrs/server5/frontend --mode config **--config-file /tmp/openmrs-sdk-hiv-4646429956995520647/configs/frontend_config/partner-notification.json --config-file /tmp/openmrs-sdk-hiv-4646429956995520647/configs/frontend_config/general-counselling.json --config-file /tmp/openmrs-sdk-hiv-4646429956995520647/configs/frontend_config/clinical-visits.json --config-file /tmp/openmrs-sdk-hiv-4646429956995520647/configs/frontend_config/config.json --config-file /tmp/openmrs-sdk-hiv-4646429956995520647/configs/frontend_config/program-management.json --config-file /tmp/openmrs-sdk-hiv-4646429956995520647/configs/frontend_config/patient-summary.json** --config /scicomp/home-pure/test/openmrs/server5/spa-build-config.json' in /scicomp/home-pure/test/openmrs-sdk

i don't see the the specified files will be merged into a single openmrs-config.json file.

![image](https://github.com/user-attachments/assets/f5a42ffb-1acd-4169-9477-f603c065768c)
