### PR TITLE
[SDK-396] SDK Setup fails on Linux due to Docker/IPv6 parsing error

### DIFF
--- a/docker-maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractDockerMojo.java
+++ b/docker-maven-plugin/src/main/java/org/openmrs/maven/plugins/AbstractDockerMojo.java
@@ -26,7 +26,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     protected static final String DEFAULT_MYSQL_EXPOSED_PORT = "3308";
     protected static final String DEFAULT_MYSQL_PASSWORD = "Admin123";
     protected static final String MYSQL_8_4_1 = "mysql:8.4.1";
-    protected static final String DEFAULT_MYSQL_DB_URI = "jdbc:mysql://localhost:" + DEFAULT_MYSQL_EXPOSED_PORT + "/";
+    protected static final String DEFAULT_MYSQL_DB_URI = "jdbc:mysql://127.0.0.1:" + DEFAULT_MYSQL_EXPOSED_PORT + "/";
     private static final Logger logger = LoggerFactory.getLogger(AbstractDockerMojo.class);
 
     private static final String NOT_LINUX_UNABLE_TO_CONNECT_MESSAGE = "\n\n\nCould not connect to Docker at " +

--- a/docker-maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateMySql.java
+++ b/docker-maven-plugin/src/main/java/org/openmrs/maven/plugins/CreateMySql.java
@@ -69,7 +69,7 @@ public class CreateMySql extends AbstractDockerMojo {
     private void createMysqlContainer(DockerClient docker) {
         if (container == null) container = DEFAULT_MYSQL_CONTAINER;
 
-        PortBinding portBinding = new PortBinding(new Ports.Binding("localhost", port), ExposedPort.tcp(3306));
+        PortBinding portBinding = new PortBinding(new Ports.Binding("127.0.0.1", port), ExposedPort.tcp(3306));
 
         Map<String, String> labels = new HashMap<>();
         labels.put(container, "true");

--- a/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DBConnector.java
+++ b/maven-plugin/src/main/java/org/openmrs/maven/plugins/utility/DBConnector.java
@@ -7,38 +7,30 @@ import java.sql.Statement;
 
 import org.openmrs.maven.plugins.model.Server;
 
-private static final int  MAX_RETRIES = 15;
 public class DBConnector implements AutoCloseable {
 
 	Connection connection;
 
 	String dbName;
 
-
-
 	public DBConnector(String url, String user, String pass, String dbName) throws SQLException {
 		DriverManager.setLoginTimeout(60);
 		this.dbName = dbName;
 
-		//  LOGIC: Retry up to 15 times (15 seconds)
-
-		for (int i = 0; i < MAX_RETRIES; i++) {
+		// NEW LOGIC: Retry up to 15 times (15 seconds)
+		int maxRetries = 15;
+		for (int i = 0; i < maxRetries; i++) {
 			try {
-				// Try to connect
 				this.connection = DriverManager.getConnection(url, user, pass);
-
 				break;
-
 			} catch (SQLException e) {
 				// If this was the last attempt, give up and crash
 				if (i == maxRetries - 1) {
 					if (e.getMessage().contains("Access denied")) {
 						throw new SQLException("Invalid database credentials. Please check your username and password.", e);
 					}
-					throw e; // Throw the actual error
+					throw e;
 				}
-
-				// If not the last attempt, Wait 1 second and loop again
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException ie) {


### PR DESCRIPTION
## Description of what I changed
Fixed the SDK setup process crashing on Linux environments. 
This PR addresses two setup blockers I encountered sequentially on Linux:
1. Changed Docker bindings from `localhost` to `127.0.0.1` to prevent IPv6 `ParseAddr` errors.
2. Added a connection retry mechanism because the MySQL container initialization caused a `Socket.connect` timeout before the DB was fully ready.

## Issue I worked on
see https://issues.openmrs.org/browse/SDK-396

## Checklist: I completed these to help reviewers :)
- [x] My code follows the code style of this project.
- [x] I have read the contributing guidelines.
- [x] I have added/updated necessary tests.
- [x] All new and existing tests passed.